### PR TITLE
fix: infra 모듈 bootjar 비활성화

### DIFF
--- a/infra/build.gradle
+++ b/infra/build.gradle
@@ -52,6 +52,15 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter'
 }
 
+bootJar{
+    enabled = false
+}
+
+jar{
+    enabled = true
+}
+
+
 test {
     useJUnitPlatform()
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#12 

## 📝작업 내용

infra모듈은 실행모듈이 아니라 bootJar 빌드를 비활성화하고 Jar빌드만 활성화하였습니다

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
