### PR TITLE
[FEAT] 해외 주식 기능 구현

### DIFF
--- a/domain/src/main/java/com/fintory/domain/stock/dto/overseas/core/OverseasStockPriceHistory.java
+++ b/domain/src/main/java/com/fintory/domain/stock/dto/overseas/core/OverseasStockPriceHistory.java
@@ -1,0 +1,27 @@
+package com.fintory.domain.stock.dto.overseas.core;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+import java.math.BigDecimal;
+
+
+public record OverseasStockPriceHistory (
+
+    @JsonAlias("ovrs_nmix_oprc")
+     BigDecimal openPrice,
+
+    @JsonAlias("ovrs_nmix_hgpr")
+     BigDecimal highPrice,
+
+    @JsonAlias("ovrs_nmix_lwpr")
+     BigDecimal  lowPrice,
+
+    @JsonAlias("ovrs_nmix_prpr")
+     BigDecimal closePrice,
+
+    @JsonAlias("stck_bsop_date")
+    String time
+
+    ){}

--- a/domain/src/main/java/com/fintory/domain/stock/dto/overseas/core/OverseasStockRankData.java
+++ b/domain/src/main/java/com/fintory/domain/stock/dto/overseas/core/OverseasStockRankData.java
@@ -1,0 +1,11 @@
+package com.fintory.domain.stock.dto.overseas.core;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.math.BigDecimal;
+
+public record OverseasStockRankData(
+        @JsonProperty("tomv")BigDecimal marketCap,
+        @JsonProperty("pvol") Long tradingVolume,
+        @JsonProperty("p_xrat") BigDecimal roc
+        ){ }

--- a/domain/src/main/java/com/fintory/domain/stock/dto/overseas/response/OverseasRankResponse.java
+++ b/domain/src/main/java/com/fintory/domain/stock/dto/overseas/response/OverseasRankResponse.java
@@ -1,0 +1,17 @@
+package com.fintory.domain.stock.dto.overseas.response;
+
+import java.math.BigDecimal;
+
+public record OverseasRankResponse (
+        String stockName,
+        String stockCode,
+        int rank,
+        String profileImageUrl,
+        BigDecimal currentPrice,
+        BigDecimal priceChange,
+        BigDecimal priceChangeRate
+){
+    public OverseasRankResponse(String stockCode, String stockName, int rank,BigDecimal currentPrice, BigDecimal priceChange, BigDecimal priceChangeRate) {
+        this(stockCode, stockName, rank,null,currentPrice,priceChange,priceChangeRate);
+    }
+}

--- a/domain/src/main/java/com/fintory/domain/stock/dto/overseas/response/OverseasStockPriceHistoryResponse.java
+++ b/domain/src/main/java/com/fintory/domain/stock/dto/overseas/response/OverseasStockPriceHistoryResponse.java
@@ -1,0 +1,14 @@
+package com.fintory.domain.stock.dto.overseas.response;
+
+import com.fintory.domain.stock.dto.korean.core.KoreanStockPriceHistory;
+import com.fintory.domain.stock.dto.overseas.core.OverseasStockPriceHistory;
+
+import java.util.List;
+import java.util.Map;
+
+public record OverseasStockPriceHistoryResponse(
+        String code,
+        String name,
+        Map<String, List<OverseasStockPriceHistory>> chartData
+){}
+

--- a/domain/src/main/java/com/fintory/domain/stock/dto/overseas/wrapper/OverseasStockRankDataWrapper.java
+++ b/domain/src/main/java/com/fintory/domain/stock/dto/overseas/wrapper/OverseasStockRankDataWrapper.java
@@ -1,0 +1,8 @@
+package com.fintory.domain.stock.dto.overseas.wrapper;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fintory.domain.stock.dto.overseas.core.OverseasStockRankData;
+
+public record OverseasStockRankDataWrapper(
+    @JsonProperty("output") OverseasStockRankData output
+){}

--- a/domain/src/main/java/com/fintory/domain/stock/service/overseas/OverseasStockPriceHistoryService.java
+++ b/domain/src/main/java/com/fintory/domain/stock/service/overseas/OverseasStockPriceHistoryService.java
@@ -1,0 +1,45 @@
+package com.fintory.domain.stock.service.overseas;
+
+import com.fintory.domain.stock.dto.overseas.core.OverseasStockPriceHistory;
+import com.fintory.domain.stock.dto.overseas.response.OverseasStockPriceHistoryResponse;
+
+import java.util.List;
+
+public interface OverseasStockPriceHistoryService {
+    /**
+     *
+     * 모든 해외 주식의 기간별 시세를 조회하여 데이터베이스에 저장
+     *
+     * <p>다음 시점에서 자동으로 호출됩니다:</p>
+     * <ul>
+     *     <li>애플리케이션 시작 시</li>
+     *     <li>미국 장마감 후</li>
+     *     <ul>
+     *         <li>정규시간: 한국시간 05:00 (동부표준시 16:00)</li>
+     *         <li>서머타임: 한국시간 04:00 (동부서머시간 16:00)</li>
+     *     </ul>
+     * </ul>
+     */
+     void saveStockPriceHistory();
+
+
+    /**
+     *
+     *  Yahoo Finance API에서 지정된 종목의 기간별 시세(일/주/월/년) 데이터 조회 공통 메서드
+     *
+     * @param code 주식 종목 코드
+     * @param interval 데이터 간격
+     * @param range 조회 기간
+     * @return 기간별 시세 이력 데이터 리스트
+     */
+     List<OverseasStockPriceHistory> getOverseasStockItemChatPrice(String code, String interval, String range);
+
+
+    /**
+     *
+     * 지정된 종목의 기간별 시세(일/주/월/년) 데이터 조회
+     * @param code 주식 종목 코드
+     * @return 해당 주식의 기간별 시세(일/주/월/년)
+     */
+    OverseasStockPriceHistoryResponse getOverseasStockPriceHistory(String code);
+}

--- a/domain/src/main/java/com/fintory/domain/stock/service/overseas/OverseasStockRankService.java
+++ b/domain/src/main/java/com/fintory/domain/stock/service/overseas/OverseasStockRankService.java
@@ -1,0 +1,22 @@
+package com.fintory.domain.stock.service.overseas;
+
+public interface OverseasStockRankService {
+
+    /**
+     *
+     * 모든 해외 주식의 시가총액, 거래량, 등락률을 조회하여
+     * 순위를 데이터베이스에 저장
+     *
+     * <p>다음 시점에서 자동으로 호출됩니다:</p>
+     * <ul>
+     *     <li>애플리케이션 시작 시</li>
+     *     <li>미국 장마감 후</li>
+     *     <ul>
+     *         <li>정규시간: 한국시간 05:00 (동부표준시 16:00)</li>
+     *         <li>서머타임: 한국시간 04:00 (동부서머시간 16:00)</li>
+     *     </ul>
+     * </ul>
+     *
+     */
+    public void saveOverseasStockRank();
+}

--- a/infra/src/main/java/com/fintory/infra/domain/stock/service/overseas/OverseasStockPriceHistoryServiceImpl.java
+++ b/infra/src/main/java/com/fintory/infra/domain/stock/service/overseas/OverseasStockPriceHistoryServiceImpl.java
@@ -1,0 +1,174 @@
+package com.fintory.infra.domain.stock.service.overseas;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fintory.common.exception.DomainErrorCode;
+import com.fintory.common.exception.DomainException;
+import com.fintory.domain.stock.dto.overseas.core.OverseasStockPriceHistory;
+import com.fintory.domain.stock.dto.overseas.response.OverseasStockPriceHistoryResponse;
+import com.fintory.domain.stock.model.Stock;
+import com.fintory.domain.stock.model.StockPriceHistory;
+import com.fintory.domain.stock.service.overseas.OverseasStockPriceHistoryService;
+import com.fintory.infra.domain.stock.repository.StockPriceHistoryRepository;
+import com.fintory.infra.domain.stock.repository.StockRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class OverseasStockPriceHistoryServiceImpl implements OverseasStockPriceHistoryService {
+
+    private final StockPriceHistoryRepository stockPriceHistoryRepository;
+    private final StockRepository stockRepository;
+    private final ObjectMapper objectMapper;
+
+    @Qualifier("yahooWebClient")
+    private final WebClient yahooWebClient;
+
+    @Override
+    @Transactional
+    public void saveStockPriceHistory(){
+        try {
+            List<Stock> stocks = stockRepository.findByCurrencyName("USD");
+
+            for (Stock stock : stocks) {
+                List<OverseasStockPriceHistory> overseasStockPriceHistories = getOverseasStockItemChartPriceDay(stock.getCode());
+
+                if (overseasStockPriceHistories == null || overseasStockPriceHistories.isEmpty()) {
+                    continue;
+                }
+
+                OverseasStockPriceHistory overseasStockPriceHistory = overseasStockPriceHistories.get(0);
+                StockPriceHistory oldStockPriceHistory = stockPriceHistoryRepository.findByStock(stock).orElseGet(()-> StockPriceHistory.builder()
+                        .stock(stock)
+                        .build());
+                oldStockPriceHistory.updateStockPriceHistory(
+                        overseasStockPriceHistory.openPrice(),
+                        overseasStockPriceHistory.highPrice(),
+                        overseasStockPriceHistory.lowPrice(),
+                        overseasStockPriceHistory.closePrice()
+                      );
+
+                stockPriceHistoryRepository.save(oldStockPriceHistory);
+            }
+        }catch (Exception e) {
+            log.error("해외 주식 saveStockPriceHistory 전체 실행 중 오류 발생", e);
+            throw new DomainException(DomainErrorCode.STOCK_PRICE_HISTORY_SAVE_FAILED);
+        }
+    }
+
+
+    private List<OverseasStockPriceHistory> processStockChartData(String data)  {
+
+        List<OverseasStockPriceHistory> overseasStockPriceHistories = new ArrayList<>();
+        try {
+            JsonNode node = objectMapper.readTree(data);
+            JsonNode result = node.get("chart").get("result").get(0);
+
+            JsonNode timestamps = result.get("timestamp");
+
+            JsonNode quote = result.get("indicators").get("quote").get(0);
+            JsonNode opens = quote.get("open");
+            JsonNode closes = quote.get("close");
+            JsonNode highs = quote.get("high");
+            JsonNode lows = quote.get("low");
+
+            for (int i = 0; i < timestamps.size(); i++) {
+                Long timestamp = timestamps.get(i).asLong();
+                LocalDate date = Instant.ofEpochSecond(timestamp)
+                        .atZone(ZoneId.systemDefault())
+                        .toLocalDate();
+
+                OverseasStockPriceHistory overseasStockPriceHistory = new OverseasStockPriceHistory(
+                        new BigDecimal(opens.get(i).asText()),
+                        new BigDecimal(highs.get(i).asText()),
+                        new BigDecimal(lows.get(i).asText()),
+                        new BigDecimal(closes.get(i).asText()),
+                        date.toString()
+                );
+                overseasStockPriceHistories.add(overseasStockPriceHistory);
+            }
+        }catch (Exception e){
+            log.error("차트 데이터 처리 중 에러 발생: {}",e.getMessage());
+        }
+        return overseasStockPriceHistories;
+    }
+
+    //프론트에게 전달할 데이터 생성 메서드
+    public OverseasStockPriceHistoryResponse getOverseasStockPriceHistory(String code){
+        Map<String,List<OverseasStockPriceHistory>> chartData = new HashMap<>();
+        Stock stock = stockRepository.findByCode(code).orElseThrow(()-> new DomainException(DomainErrorCode.STOCK_NOT_FOUND));
+
+        chartData.put("1D", getOverseasStockItemChartPriceDay(code));
+        chartData.put("1W", getOverseasStockItemChatPriceWeek(code));
+        chartData.put("3M", getOverseasStockItemChatPrice3Month(code));
+        chartData.put("1Y", getOverseasStockItemChatPriceYear(code));
+        chartData.put("5Y", getOverseasStockItemChatPrice5Year(code));
+        chartData.put("total", getOverseasStockItemChatPriceTotal(code));
+
+        return new OverseasStockPriceHistoryResponse(stock.getName(),code,chartData);
+    }
+
+    /*
+     *
+     * 차트 데이터 조회
+     *
+     * */
+
+    private List<OverseasStockPriceHistory> getOverseasStockItemChartPriceDay(String code) {
+        return getOverseasStockItemChatPrice(code, "1h", "1d");
+    }
+
+
+    private List<OverseasStockPriceHistory> getOverseasStockItemChatPriceWeek(String code) {
+        return getOverseasStockItemChatPrice(code, "1d", "1w");
+    }
+
+    private List<OverseasStockPriceHistory> getOverseasStockItemChatPrice3Month(String code) {
+        return getOverseasStockItemChatPrice(code, "1d", "3mo");
+    }
+
+    private List<OverseasStockPriceHistory> getOverseasStockItemChatPriceYear(String code) {
+        return getOverseasStockItemChatPrice(code, "1mo", "1y");
+    }
+
+    private List<OverseasStockPriceHistory> getOverseasStockItemChatPrice5Year(String code) {
+        return  getOverseasStockItemChatPrice(code, "1mo", "5y");
+    }
+
+    private List<OverseasStockPriceHistory> getOverseasStockItemChatPriceTotal(String code) {
+        return  getOverseasStockItemChatPrice(code, "1y", "max");
+    }
+
+    @Override
+    @Transactional
+    public List<OverseasStockPriceHistory> getOverseasStockItemChatPrice(String code, String interval, String range){
+        String data = yahooWebClient.get()
+                .uri("https://query1.finance.yahoo.com/v8/finance/chart/{symbol}?interval={interval}&range={range}",
+                        code, interval,range)
+                .exchangeToMono(response -> response.bodyToMono(String.class))
+                .block();
+
+        return processStockChartData(data);
+    }
+
+
+}

--- a/infra/src/main/java/com/fintory/infra/domain/stock/service/overseas/OverseasStockRankServiceImpl.java
+++ b/infra/src/main/java/com/fintory/infra/domain/stock/service/overseas/OverseasStockRankServiceImpl.java
@@ -1,0 +1,154 @@
+package com.fintory.infra.domain.stock.service.overseas;
+
+import com.fintory.common.exception.DomainErrorCode;
+import com.fintory.common.exception.DomainException;
+import com.fintory.domain.stock.dto.overseas.core.OverseasStockRankData;
+import com.fintory.domain.stock.dto.overseas.wrapper.OverseasStockRankDataWrapper;
+import com.fintory.domain.stock.model.Stock;
+import com.fintory.domain.stock.model.StockRank;
+import com.fintory.domain.stock.service.overseas.OverseasStockRankService;
+import com.fintory.infra.domain.stock.repository.StockRankRepository;
+import com.fintory.infra.domain.stock.repository.StockRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class OverseasStockRankServiceImpl implements OverseasStockRankService {
+
+
+    private final StockRepository stockRepository;
+    private final StockRankRepository stockRankRepository;
+    private final RedisTemplate<Object, Object> redisTemplate;
+
+    @Qualifier("kisWebClient")
+    private final WebClient kisWebClient;
+
+    @Value("${hantu-openapi.appkey}")
+    private String appkey;
+
+    @Value("${hantu-openapi.appsecret}")
+    private String appsecret;
+
+
+    //  순위 저장
+    @Override
+    @Transactional
+    public void saveOverseasStockRank(){
+
+        List<Stock> stockList = stockRepository.findByCurrencyName("USD");
+        String token = (String) redisTemplate.opsForValue().get("kis-access-token");
+
+        int batchSize=10;
+
+        for(int i=0;i<stockList.size();i+=batchSize){
+            List<Stock> batch = stockList.subList(i,Math.min(i+batchSize,stockList.size()));
+
+            List<Mono<Void>> request = batch.stream()
+                    .map(stock-> processStockRankData(stock.getCode(),token))
+                    .collect(Collectors.toList());
+
+
+            //배치 단위로 모든 요청 완료까지 대기
+            Mono.when(request).block();
+        }
+        processStockRank();
+    }
+
+
+    //순위를 얻는데 필요한 데이터 조회
+    private Mono<Void> processStockRankData(String code, String token) {
+        return  kisWebClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/uapi/domestic-stock/v1/quotations/inquire-price")
+                        .queryParam("AUTH","")
+                        .queryParam("EXCD", "NAS")
+                        .queryParam("SYMB", code)
+                        .build())
+                .header("authorization", "Bearer "+token)
+                .header("appkey", appkey)
+                .header("appsecret", appsecret)
+                .header("tr_id", "HHDFS76200200")
+                .header("custtype", "P")
+                .retrieve()
+                .bodyToMono(OverseasStockRankDataWrapper.class)
+                .doOnNext(rank-> saveStockRankData(code,rank))
+                .onErrorMap(e -> {
+                    log.error("순위 관련 데이터 조회 실패: {} - {}", code, e.getMessage());
+                    throw new DomainException(DomainErrorCode.API_RESPONSE_EMPTY);
+                })
+                .then();
+    }
+
+    //순위를 얻는데 필요한 데이터 저장 메서드
+    private void saveStockRankData(String code, OverseasStockRankDataWrapper response) {
+
+        if (response == null || response.output() == null) {
+            log.warn("순위 관련 데이터 응답이 비어있음: {}", code);
+            throw new DomainException(DomainErrorCode.API_RESPONSE_EMPTY);
+        }
+
+        OverseasStockRankData item = response.output();
+
+        if (item == null) {
+            log.warn("순위 관련 응답에서 데이터를 찾을 수 없음");
+            throw new DomainException(DomainErrorCode.STOCK_DATA_NOT_FOUND);
+        }
+
+        StockRank stockRank = stockRankRepository.findByStockCode(code).orElse(null);
+        Stock stock = stockRepository.findByCode(code).orElseThrow(()->new DomainException(DomainErrorCode.STOCK_NOT_FOUND));
+
+        if (stockRank == null) {
+            stockRank = StockRank.builder()
+                    .tradingVolume(item.tradingVolume())
+                    .rocRate(item.roc())
+                    .marketCap(item.marketCap())
+                    .stock(stock)
+                    .build();
+        } else {
+            stockRank.updateStockRankData(item.marketCap(), item.roc(), item.tradingVolume());
+        }
+
+        stockRankRepository.save(stockRank);
+    }
+
+    //순위 데이터 생성 및 저장
+    private void processStockRank(){
+        List<StockRank> marketCapRankList = stockRankRepository.findAllOrderByMarketCap("USD");
+        List<StockRank> rocRankList = stockRankRepository.findAllOrderByRocRate("USD");
+        List<StockRank> tradingVolumeRankList = stockRankRepository.findAllOrderByTradingVolume("USD");
+
+
+        for (int i = 0; i < marketCapRankList.size(); i++) {
+            StockRank stockRank = marketCapRankList.get(i);
+            stockRank.updateMarketCapRank(i + 1);
+            stockRankRepository.save(stockRank);
+        }
+
+
+        for (int i = 0; i < rocRankList.size(); i++) {
+            StockRank stockRank = rocRankList.get(i);
+            stockRank.updateRocRank(i + 1);
+            stockRankRepository.save(stockRank);
+        }
+
+
+        for (int i = 0; i < tradingVolumeRankList.size(); i++) {
+            StockRank stockRank = tradingVolumeRankList.get(i);
+            stockRank.updateTradingVolumeRank(i + 1);
+            stockRankRepository.save(stockRank);
+        }
+
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #23 

## 📝작업 내용

> 해외 주식 기간별 시세 기능 구현
> 해외 주식 순위 관련 데이터 조회하고 순위 테이블 생성

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

>  보다 원활한 리뷰를 위해 일부 코드만 커밋 & 푸시를 하고 있는 상황인데 그럼 커밋 히스토리 정리를 위한 git rebase는 마지막 푸시때 할려고 하는데 이러면 문제 생길까요?
