### PR TITLE
경재 용어 api 기능

### DIFF
--- a/app-child/src/main/java/com/fintory/child/domain/financialword/controller/FinancialwordController.java
+++ b/app-child/src/main/java/com/fintory/child/domain/financialword/controller/FinancialwordController.java
@@ -1,0 +1,41 @@
+package com.fintory.child.domain.financialword.controller;
+
+import com.fintory.common.api.ApiResponse;
+import com.fintory.domain.financialword.dto.WordResponse;
+import com.fintory.domain.financialword.dto.WordSummaryResponse;
+import com.fintory.domain.financialword.dto.WordTitleResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Size;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+@Tag(name = "경제 용어 API")
+public interface FinancialwordController {
+
+    @Operation(summary = "용어 상세 조회")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "용어 상세 조회 결과 반환")
+    ResponseEntity<ApiResponse<WordResponse>> getWord(@PathVariable Long id);
+
+    @Operation(summary = "용어 전체 목록 조회")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "용어 전체 목록 조회 결과 반환")
+    ResponseEntity<ApiResponse<List<WordTitleResponse>>> getWordList();
+
+    @Operation(summary = "오늘의 용어 (랜덤) 미리보기 조회")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "랜덤 단어 이름, id 반환")
+    ResponseEntity<ApiResponse<WordSummaryResponse>> getRandomWord();
+
+    // 챗봇 형태로 다른 페이지에서도 즉석으로 호출해도 괜찮을 지도?
+    @Operation(summary = "용어 검색")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "검색된 모든 단어 리스트 반환")
+    ResponseEntity<ApiResponse<List<WordTitleResponse>>> searchWord(
+            @Parameter(description = "검색할 키워드. 한 글자도 가능", required = true)
+            @RequestParam
+            @Size(min = 1, max = 20, message = "1~20자 이내로 검색해주세요")
+            String keyword
+    );
+}

--- a/app-child/src/main/java/com/fintory/child/domain/financialword/controller/FinancialwordControllerImpl.java
+++ b/app-child/src/main/java/com/fintory/child/domain/financialword/controller/FinancialwordControllerImpl.java
@@ -1,0 +1,55 @@
+package com.fintory.child.domain.financialword.controller;
+
+import com.fintory.common.api.ApiResponse;
+import com.fintory.domain.financialword.dto.WordResponse;
+import com.fintory.domain.financialword.dto.WordSummaryResponse;
+import com.fintory.domain.financialword.dto.WordTitleResponse;
+import com.fintory.domain.financialword.service.WordService;
+import jakarta.validation.constraints.Size;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/child/financialword")
+@RequiredArgsConstructor
+public class FinancialwordControllerImpl implements FinancialwordController{
+
+    private final WordService wordService;
+
+    @Override
+    @GetMapping("/get-word/{id}")
+    public ResponseEntity<ApiResponse<WordResponse>> getWord(@PathVariable Long id) {
+        WordResponse response = wordService.getWordById(id);
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    @Override
+    @GetMapping("/get-word-list")
+    public ResponseEntity<ApiResponse<List<WordTitleResponse>>> getWordList() {
+        List<WordTitleResponse> words = wordService.getWordList();
+        return ResponseEntity.ok(ApiResponse.ok(words));
+    }
+
+    @Override
+    @GetMapping("/get-random-word")
+    public ResponseEntity<ApiResponse<WordSummaryResponse>> getRandomWord() {
+        WordSummaryResponse summary = wordService.getRandomWordSummary();
+        return ResponseEntity.ok(ApiResponse.ok(summary));
+    }
+
+    @Override
+    @GetMapping("/get-search-word-list")
+    public ResponseEntity<ApiResponse<List<WordTitleResponse>>> searchWord(
+            @RequestParam
+            @Size(min = 1, max = 20, message = "1~20자 이내로 검색해주세요")
+            String keyword
+    ) {
+        List<WordTitleResponse> searchList = wordService.getSearchWordList(keyword);
+        return ResponseEntity.ok(ApiResponse.ok(searchList));
+    }
+
+
+}

--- a/auth/src/main/java/com/fintory/auth/controller/AuthControllerImpl.java
+++ b/auth/src/main/java/com/fintory/auth/controller/AuthControllerImpl.java
@@ -16,13 +16,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
 
 @Slf4j
-@Validated
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")

--- a/common/src/main/java/com/fintory/common/exception/DomainErrorCode.java
+++ b/common/src/main/java/com/fintory/common/exception/DomainErrorCode.java
@@ -29,6 +29,8 @@ public enum DomainErrorCode {
     NEWS_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "NEWS_NOT_FOUND", "저장된 뉴스 기사 불러오기 실패"),
     NEWS_CRAWLING_FAILED(HttpStatus.BAD_GATEWAY, "NEWS_CRAWLING_FAILED", "뉴스 기사 크롤링 실패"),
 
+    //financial word
+    WORD_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "WORD_NOT_FOUND", "경제 용어 불러오기 실패"),
     //account
     ACCOUNT_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR,"ACCOUNT_NOT_FOUND","계좌 불러오기 실패"),
 

--- a/domain/src/main/java/com/fintory/domain/common/BaseEntity.java
+++ b/domain/src/main/java/com/fintory/domain/common/BaseEntity.java
@@ -18,7 +18,7 @@ public class BaseEntity {
     private Long id;
 
     @CreatedDate
-    @Column(name = "created_at", nullable = false, updatable = false)
+    @Column(name = "created_at", updatable = false, nullable = true)
     private LocalDateTime createdAt;
 
     @LastModifiedDate

--- a/domain/src/main/java/com/fintory/domain/financialword/dto/WordResponse.java
+++ b/domain/src/main/java/com/fintory/domain/financialword/dto/WordResponse.java
@@ -1,0 +1,19 @@
+package com.fintory.domain.financialword.dto;
+
+import com.fintory.domain.financialword.model.FinancialWord;
+
+public record WordResponse(
+        String word,
+        String definition,
+        String moreInfo
+) {
+
+    public static WordResponse from(FinancialWord word) {
+        return new WordResponse(
+                word.getWord(),
+                word.getDefinition(),
+                word.getMoreInfo()
+        );
+    }
+
+}

--- a/domain/src/main/java/com/fintory/domain/financialword/dto/WordSummaryResponse.java
+++ b/domain/src/main/java/com/fintory/domain/financialword/dto/WordSummaryResponse.java
@@ -1,0 +1,17 @@
+package com.fintory.domain.financialword.dto;
+
+import com.fintory.domain.financialword.model.FinancialWord;
+
+public record WordSummaryResponse(
+        Long id,
+        String word,
+        String summary
+) {
+    public static WordSummaryResponse from(FinancialWord word) {
+        return new WordSummaryResponse(
+                word.getId(),
+                word.getWord(),
+                word.getDefinition()
+        );
+    }
+}

--- a/domain/src/main/java/com/fintory/domain/financialword/dto/WordTitleResponse.java
+++ b/domain/src/main/java/com/fintory/domain/financialword/dto/WordTitleResponse.java
@@ -1,0 +1,17 @@
+package com.fintory.domain.financialword.dto;
+
+import com.fintory.domain.financialword.model.FinancialWord;
+
+public record WordTitleResponse(
+
+        Long id,
+        String word
+) {
+
+    public static WordTitleResponse from(FinancialWord word) {
+        return new WordTitleResponse(
+                word.getId(),
+                word.getWord()
+        );
+    }
+}

--- a/domain/src/main/java/com/fintory/domain/financialword/model/FinancialWord.java
+++ b/domain/src/main/java/com/fintory/domain/financialword/model/FinancialWord.java
@@ -13,9 +13,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FinancialWord extends BaseEntity {
 
-    private String content;
+    private String word;
 
-    private String title;
+    private String definition;
+
+    private String moreInfo;
 
     @OneToOne(mappedBy = "word")
     private Quiz quiz;

--- a/domain/src/main/java/com/fintory/domain/financialword/service/WordService.java
+++ b/domain/src/main/java/com/fintory/domain/financialword/service/WordService.java
@@ -1,0 +1,18 @@
+package com.fintory.domain.financialword.service;
+
+import com.fintory.domain.financialword.dto.WordResponse;
+import com.fintory.domain.financialword.dto.WordSummaryResponse;
+import com.fintory.domain.financialword.dto.WordTitleResponse;
+
+import java.util.List;
+
+public interface WordService {
+
+    WordResponse getWordById(Long id);
+
+    List<WordTitleResponse> getWordList();
+
+    WordSummaryResponse getRandomWordSummary();
+
+    List<WordTitleResponse> getSearchWordList(String keyword);
+}

--- a/infra/src/main/java/com/fintory/infra/domain/word/repository/WordRepository.java
+++ b/infra/src/main/java/com/fintory/infra/domain/word/repository/WordRepository.java
@@ -1,0 +1,20 @@
+package com.fintory.infra.domain.word.repository;
+
+import com.fintory.domain.financialword.model.FinancialWord;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface WordRepository extends JpaRepository<FinancialWord, Long> {
+
+    Optional<FinancialWord> findFirstByWord(String word);
+
+    @Query(value = "SELECT * FROM Financial_word ORDER BY RAND() LIMIT 1", nativeQuery = true)
+    Optional<FinancialWord> wordRepositoryRandomWord();
+
+    @Query("SELECT f FROM FinancialWord f WHERE f.word LIKE %:keyword%")
+    List<FinancialWord> searchByKeyword(@Param("keyword") String keyword);
+}

--- a/infra/src/main/java/com/fintory/infra/domain/word/serviceimpl/WordServiceImpl.java
+++ b/infra/src/main/java/com/fintory/infra/domain/word/serviceimpl/WordServiceImpl.java
@@ -1,0 +1,53 @@
+package com.fintory.infra.domain.word.serviceimpl;
+
+import com.fintory.common.exception.DomainErrorCode;
+import com.fintory.common.exception.DomainException;
+import com.fintory.domain.financialword.dto.WordResponse;
+import com.fintory.domain.financialword.dto.WordSummaryResponse;
+import com.fintory.domain.financialword.dto.WordTitleResponse;
+import com.fintory.domain.financialword.service.WordService;
+import com.fintory.infra.domain.word.repository.WordRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class WordServiceImpl implements WordService {
+
+    private final WordRepository wordRepository;
+
+    @Override
+    public WordResponse getWordById(Long id) {
+        return wordRepository.findById(id)
+                .map(WordResponse::from)
+                .orElseThrow(() -> new DomainException(DomainErrorCode.WORD_NOT_FOUND));
+    }
+
+    @Override
+    public List<WordTitleResponse> getWordList() {
+        return wordRepository.findAll()
+                .stream()
+                .map(WordTitleResponse::from)
+                .toList();
+    }
+
+    @Override
+    public WordSummaryResponse getRandomWordSummary() {
+
+        return wordRepository.wordRepositoryRandomWord()
+                .map(WordSummaryResponse::from)
+                .orElseThrow(() -> new DomainException(DomainErrorCode.WORD_NOT_FOUND));
+    }
+
+    @Override
+    public List<WordTitleResponse> getSearchWordList(String keyword) {
+
+        return wordRepository.searchByKeyword(keyword)
+                .stream()
+                .map(WordTitleResponse::from)
+                .toList();
+    }
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #21 

## 📝작업 내용

- 경제 용어 개별 상세 조회 api
- 경제 용어 전체 목록 조회 api (단어 이름만)
- 검색 api (빈 리스트 혹은 조건을 만족하는 여러 단어가 반환될 수 있음)
- 오늘의 단어(랜덤 단어 조회) api  

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
