### PR TITLE
[FEAT] MarketStack API를 활용한 주식 관련 기능 구현 

### DIFF
--- a/app-child/src/main/resources/application-local.yml
+++ b/app-child/src/main/resources/application-local.yml
@@ -46,3 +46,5 @@ management:
     health:
       show-details: always
 
+market-stack:
+  access-key: ${MARKET_STACK_ACCESS_KEY}

--- a/auth/src/main/java/com/fintory/auth/util/OpenApiList.java
+++ b/auth/src/main/java/com/fintory/auth/util/OpenApiList.java
@@ -26,7 +26,11 @@ public class OpenApiList {
             "/v3/api-docs/**",
 
             // news
-            "/api/news/crawl-test"
+            "/api/news/crawl-test",
+
+            //stock
+            //NOTE 시중에 나와있는 앱들은 로그인 없이도 주식 데이터 확인이 가능해서 일단 열어둠. 추후 변경 가능
+            "/api/child/stock/**"
 
     };
 }

--- a/common/src/main/java/com/fintory/common/exception/DomainErrorCode.java
+++ b/common/src/main/java/com/fintory/common/exception/DomainErrorCode.java
@@ -32,6 +32,20 @@ public enum DomainErrorCode {
     //account
     ACCOUNT_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR,"ACCOUNT_NOT_FOUND","계좌 불러오기 실패"),
 
+    //API
+    API_FAILED(HttpStatus.SERVICE_UNAVAILABLE,"API_FAILED","API 응답 받기 실패"),
+
+    STOCK_PRICE_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND,"STOCK_PRICE_HISTORY_NOT_FOUND","기간별 시세 데이터 불러오기 실패"),
+
+    //order_book
+    ORDER_BOOK_NOT_FOUND(HttpStatus.NOT_FOUND,"ORDER_BOOK_NOT_FOUND","호가 데이터를 찾을 수 없습니다."),
+
+    //stock
+    STOCK_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR,"STOCK_NOT_FOUND","주식 불러오기 실패"),
+
+    //live_stock_price
+    LIVE_STOCK_PRICE_NOT_FOUND(HttpStatus.NOT_FOUND,"LIVE_STOCK_PRICE_NOT_FOUND","현재가 데이터를 찾을 수 없습니다."),
+
     //ownedStock
     OWNED_STOCK_LIST_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "OWNED_STOCK_LIST_ERROR", "보유 종목 리스트 조회 중 오류 발생"),
     PORTFOLIO_CALCULATION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"PORTFOLIO_CALCULATION_ERROR","포트폴리오 계산 중 오류 발생");

--- a/common/src/main/java/com/fintory/common/exception/DomainErrorCode.java
+++ b/common/src/main/java/com/fintory/common/exception/DomainErrorCode.java
@@ -33,8 +33,9 @@ public enum DomainErrorCode {
     ACCOUNT_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR,"ACCOUNT_NOT_FOUND","계좌 불러오기 실패"),
 
     //API
-    API_FAILED(HttpStatus.SERVICE_UNAVAILABLE,"API_FAILED","API 응답 받기 실패"),
-
+    API_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "API_FAILED", "일시적으로 서비스를 사용할 수 없습니다. 잠시 후 다시 시도해주세요"),
+    API_RESPONSE_NULL(HttpStatus.BAD_GATEWAY,"API_RESPONSE_NULL","API 응답이 비어있습니다."),
+    //Stock Price History
     STOCK_PRICE_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND,"STOCK_PRICE_HISTORY_NOT_FOUND","기간별 시세 데이터 불러오기 실패"),
 
     //order_book

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -37,6 +37,9 @@ dependencies {
 
     /* Actuator */
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    /* Jackson */
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
 }
 
 test {

--- a/domain/src/main/java/com/fintory/domain/stock/dto/EODResponse.java
+++ b/domain/src/main/java/com/fintory/domain/stock/dto/EODResponse.java
@@ -1,0 +1,16 @@
+package com.fintory.domain.stock.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.math.BigDecimal;
+
+public record EODResponse(
+        @JsonProperty("open")BigDecimal open,
+        @JsonProperty("high")BigDecimal high,
+        @JsonProperty("low") BigDecimal low,
+        @JsonProperty("close") BigDecimal close,
+        @JsonProperty("volume") double volume,
+        @JsonProperty("symbol") String symbol
+
+        ) {
+ }

--- a/domain/src/main/java/com/fintory/domain/stock/dto/EODResponseWrapper.java
+++ b/domain/src/main/java/com/fintory/domain/stock/dto/EODResponseWrapper.java
@@ -1,0 +1,10 @@
+package com.fintory.domain.stock.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record EODResponseWrapper(
+        @JsonProperty("data") List<EODResponse> eodResponseList
+) {
+}

--- a/domain/src/main/java/com/fintory/domain/stock/dto/IntraDayResponse.java
+++ b/domain/src/main/java/com/fintory/domain/stock/dto/IntraDayResponse.java
@@ -1,0 +1,15 @@
+package com.fintory.domain.stock.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.math.BigDecimal;
+
+public record IntraDayResponse(
+        @JsonProperty("open") BigDecimal open,
+        @JsonProperty("high")BigDecimal high,
+        @JsonProperty("low") BigDecimal low,
+        @JsonProperty("close") BigDecimal close,
+        @JsonProperty("symbol") String symbol,
+        @JsonProperty("date") String date
+) {
+}

--- a/domain/src/main/java/com/fintory/domain/stock/dto/IntraDayResponseWrapper.java
+++ b/domain/src/main/java/com/fintory/domain/stock/dto/IntraDayResponseWrapper.java
@@ -1,0 +1,9 @@
+package com.fintory.domain.stock.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record IntraDayResponseWrapper(
+        @JsonProperty("data") List<IntraDayResponse> intraDayResponseList
+) { }

--- a/domain/src/main/java/com/fintory/domain/stock/dto/LiveStockPriceResponse.java
+++ b/domain/src/main/java/com/fintory/domain/stock/dto/LiveStockPriceResponse.java
@@ -1,0 +1,11 @@
+package com.fintory.domain.stock.dto;
+
+import java.math.BigDecimal;
+
+public record LiveStockPriceResponse(
+        BigDecimal currentPrice,
+        BigDecimal priceChange,
+        BigDecimal priceChangeRate,
+        String stockName
+) {
+}

--- a/domain/src/main/java/com/fintory/domain/stock/dto/RankResponse.java
+++ b/domain/src/main/java/com/fintory/domain/stock/dto/RankResponse.java
@@ -1,0 +1,17 @@
+package com.fintory.domain.stock.dto;
+
+import java.math.BigDecimal;
+
+public record RankResponse(
+        String stockCode,
+        String stockName,
+        int rank,
+        String profileImageUrl,
+        BigDecimal currentPrice,
+        BigDecimal priceChange,
+        BigDecimal priceChangeRate
+){
+    public RankResponse(String stockCode, String stockName, int rank, BigDecimal currentPrice, BigDecimal priceChange, BigDecimal priceChangeRate) {
+        this(stockCode, stockName, rank,null,currentPrice,priceChange,priceChangeRate);
+    }
+}

--- a/domain/src/main/java/com/fintory/domain/stock/dto/StockPriceHistoryResponse.java
+++ b/domain/src/main/java/com/fintory/domain/stock/dto/StockPriceHistoryResponse.java
@@ -1,0 +1,21 @@
+package com.fintory.domain.stock.dto;
+
+import com.fintory.domain.stock.model.IntervalType;
+
+import java.math.BigDecimal;
+
+public record StockPriceHistoryResponse(
+         BigDecimal openPrice,
+
+         BigDecimal closePrice,
+
+         BigDecimal highPrice,
+
+         BigDecimal lowPrice,
+
+         IntervalType intervalType,
+
+         String date
+
+) {
+}

--- a/domain/src/main/java/com/fintory/domain/stock/dto/StockPriceHistoryWrapper.java
+++ b/domain/src/main/java/com/fintory/domain/stock/dto/StockPriceHistoryWrapper.java
@@ -1,0 +1,27 @@
+package com.fintory.domain.stock.dto;
+
+import com.fintory.domain.stock.model.IntervalType;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public record StockPriceHistoryWrapper(
+        String code,
+        String name,
+        Map<IntervalType, List<StockPriceHistoryResponse>> charData
+) {
+    public StockPriceHistoryWrapper(String code, String name){
+        this(code, name, createInitialMap());
+    }
+
+    private static Map<IntervalType, List<StockPriceHistoryResponse>> createInitialMap() {
+        Map<IntervalType, List<StockPriceHistoryResponse>> map = new HashMap<>();
+        map.put(IntervalType.FIVEYEARLY, null);
+        map.put(IntervalType.MONTHLY, null);
+        map.put(IntervalType.YEARLY, null);
+        map.put(IntervalType.WEEKLY, null);
+        map.put(IntervalType.TOTAL, null);
+        return map;
+    }
+}

--- a/domain/src/main/java/com/fintory/domain/stock/model/IntervalType.java
+++ b/domain/src/main/java/com/fintory/domain/stock/model/IntervalType.java
@@ -1,5 +1,5 @@
 package com.fintory.domain.stock.model;
 
 public enum IntervalType {
-    daily, monthly, yearly
+    DAILY,WEEKLY, MONTHLY, YEARLY, FIVEYEARLY, TOTAL
 }

--- a/domain/src/main/java/com/fintory/domain/stock/model/LiveStockPrice.java
+++ b/domain/src/main/java/com/fintory/domain/stock/model/LiveStockPrice.java
@@ -2,27 +2,52 @@ package com.fintory.domain.stock.model;
 
 
 import com.fintory.domain.common.BaseEntity;
+import com.fintory.domain.stock.dto.EODResponse;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.util.List;
 
 @Entity
 @Getter
 @Table(name="live_stock_price")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class LiveStockPrice extends BaseEntity {
 
     @Column(name="current_price")
-    private int currentPrice;
+    private BigDecimal currentPrice;
 
     @Column(name="price_change")
-    private int priceChange;
+    private BigDecimal priceChange;
 
     @Column(name="price_change_rate")
-    private int priceChangeRate;
+    private BigDecimal priceChangeRate;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="stock_id")
     private Stock stock;
+
+    public LiveStockPrice updateLiveStockPrice(List<EODResponse> response){
+            // 최신 데이터 (인덱스 0)와 전일 데이터 (인덱스 1)
+            BigDecimal todayClose = response.get(0).close();
+            BigDecimal yesterdayClose = response.get(1).close();
+
+            BigDecimal rate=null;
+
+            // 등락률 계산: (오늘 종가 - 어제 종가) / 어제 종가 * 100
+            if(todayClose!=null &&  yesterdayClose!=null &&
+                yesterdayClose.compareTo(BigDecimal.ZERO)!=0 && todayClose.compareTo(BigDecimal.ZERO)!=0){
+                rate = (todayClose.subtract(yesterdayClose)
+                        .divide(yesterdayClose, 2, BigDecimal.ROUND_HALF_UP)
+                        .multiply(BigDecimal.valueOf(100)));
+            }
+
+            this.currentPrice = todayClose;
+            this.priceChange = todayClose.subtract(yesterdayClose);
+            this.priceChangeRate = rate;
+            return this;
+    }
 }

--- a/domain/src/main/java/com/fintory/domain/stock/model/OrderBook.java
+++ b/domain/src/main/java/com/fintory/domain/stock/model/OrderBook.java
@@ -6,141 +6,141 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
+
 @Entity
 @Getter
 @Table(name = "order_book")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class OrderBook extends BaseEntity {
 
-    @Column(name = "stock_id")
-    private Long stockId;
-
     // 매도호가
     @Column(name = "sell_price_1", length = 4)
-    private String sellPrice1;
+    private BigDecimal sellPrice1;
 
     @Column(name = "sell_price_2", length = 4)
-    private String sellPrice2;
+    private BigDecimal sellPrice2;
 
     @Column(name = "sell_price_3", length = 4)
-    private String sellPrice3;
+    private BigDecimal sellPrice3;
 
     @Column(name = "sell_price_4", length = 4)
-    private String sellPrice4;
+    private BigDecimal sellPrice4;
 
     @Column(name = "sell_price_5", length = 4)
-    private String sellPrice5;
+    private BigDecimal sellPrice5;
 
     @Column(name = "sell_price_6", length = 4)
-    private String sellPrice6;
+    private BigDecimal sellPrice6;
 
     @Column(name = "sell_price_7", length = 4)
-    private String sellPrice7;
+    private BigDecimal sellPrice7;
 
     @Column(name = "sell_price_8", length = 4)
-    private String sellPrice8;
+    private BigDecimal sellPrice8;
 
     @Column(name = "sell_price_9", length = 4)
-    private String sellPrice9;
+    private BigDecimal sellPrice9;
 
     @Column(name = "sell_price_10", length = 4)
-    private String sellPrice10;
+    private BigDecimal sellPrice10;
 
     // 매수호가
     @Column(name = "buy_price_1", length = 4)
-    private String buyPrice1;
+    private BigDecimal buyPrice1;
 
     @Column(name = "buy_price_2", length = 4)
-    private String buyPrice2;
+    private BigDecimal buyPrice2;
 
     @Column(name = "buy_price_3", length = 4)
-    private String buyPrice3;
+    private BigDecimal buyPrice3;
 
     @Column(name = "buy_price_4", length = 4)
-    private String buyPrice4;
+    private BigDecimal buyPrice4;
 
     @Column(name = "buy_price_5", length = 4)
-    private String buyPrice5;
+    private BigDecimal buyPrice5;
 
     @Column(name = "buy_price_6", length = 4)
-    private String buyPrice6;
+    private BigDecimal buyPrice6;
 
     @Column(name = "buy_price_7", length = 4)
-    private String buyPrice7;
+    private BigDecimal buyPrice7;
 
     @Column(name = "buy_price_8", length = 4)
-    private String buyPrice8;
+    private BigDecimal buyPrice8;
 
     @Column(name = "buy_price_9", length = 4)
-    private String buyPrice9;
+    private BigDecimal buyPrice9;
 
     @Column(name = "buy_price_10", length = 4)
-    private String buyPrice10;
+    private BigDecimal buyPrice10;
 
     // 매도호가 잔량
     @Column(name = "sell_quantity_1", length = 8)
-    private String sellQuantity1;
+    private Long sellQuantity1;
 
     @Column(name = "sell_quantity_2", length = 8)
-    private String sellQuantity2;
+    private Long sellQuantity2;
 
     @Column(name = "sell_quantity_3", length = 8)
-    private String sellQuantity3;
+    private Long sellQuantity3;
 
     @Column(name = "sell_quantity_4", length = 8)
-    private String sellQuantity4;
+    private Long sellQuantity4;
 
     @Column(name = "sell_quantity_5", length = 8)
-    private String sellQuantity5;
+    private Long sellQuantity5;
 
     @Column(name = "sell_quantity_6", length = 8)
-    private String sellQuantity6;
+    private Long sellQuantity6;
 
     @Column(name = "sell_quantity_7", length = 8)
-    private String sellQuantity7;
+    private Long sellQuantity7;
 
     @Column(name = "sell_quantity_8", length = 8)
-    private String sellQuantity8;
+    private Long sellQuantity8;
 
     @Column(name = "sell_quantity_9", length = 8)
-    private String sellQuantity9;
+    private Long sellQuantity9;
 
     @Column(name = "sell_quantity_10", length = 8)
-    private String sellQuantity10;
+    private Long sellQuantity10;
 
     // 매수호가 잔량
     @Column(name = "buy_quantity_1", length = 8)
-    private String buyQuantity1;
+    private Long buyQuantity1;
 
     @Column(name = "buy_quantity_2", length = 8)
-    private String buyQuantity2;
+    private Long buyQuantity2;
 
     @Column(name = "buy_quantity_3", length = 8)
-    private String buyQuantity3;
+    private Long buyQuantity3;
 
     @Column(name = "buy_quantity_4", length = 8)
-    private String buyQuantity4;
+    private Long buyQuantity4;
 
     @Column(name = "buy_quantity_5", length = 8)
-    private String buyQuantity5;
+    private Long buyQuantity5;
 
     @Column(name = "buy_quantity_6", length = 8)
-    private String buyQuantity6;
+    private Long buyQuantity6;
 
     @Column(name = "buy_quantity_7", length = 8)
-    private String buyQuantity7;
+    private Long buyQuantity7;
 
     @Column(name = "buy_quantity_8", length = 8)
-    private String buyQuantity8;
+    private Long buyQuantity8;
 
     @Column(name = "buy_quantity_9", length = 8)
-    private String buyQuantity9;
+    private Long buyQuantity9;
 
     @Column(name = "buy_quantity_10", length = 8)
-    private String buyQuantity10;
+    private Long buyQuantity10;
 
     // 연관관계
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "stock_id", insertable = false, updatable = false)
+    @JoinColumn(name = "stock_id")
     private Stock stock;
+
 }

--- a/domain/src/main/java/com/fintory/domain/stock/model/StockPriceHistory.java
+++ b/domain/src/main/java/com/fintory/domain/stock/model/StockPriceHistory.java
@@ -2,32 +2,35 @@ package com.fintory.domain.stock.model;
 
 import com.fintory.domain.common.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
+
+import java.math.BigDecimal;
 
 @Entity
 @Getter
 @Table(name="stock_price_history")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class StockPriceHistory extends BaseEntity {
 
     @Column(name="open_price")
-    private int openPrice;
+    private BigDecimal openPrice;
 
     @Column(name="close_price")
-    private int closePrice;
+    private BigDecimal closePrice;
 
     @Column(name="high_price")
-    private int highPrice;
+    private BigDecimal highPrice;
 
     @Column(name="low_price")
-    private int lowPrice;
-
-    private int volume; //거래량
+    private BigDecimal lowPrice;
 
     @Enumerated(EnumType.STRING)
+    @Column(name="interval_type",length = 15)
     private IntervalType intervalType;
+
+    private String date;
 
     @ManyToOne(fetch=FetchType.LAZY)
     @JoinColumn(name="stock_id")

--- a/domain/src/main/java/com/fintory/domain/stock/model/StockRank.java
+++ b/domain/src/main/java/com/fintory/domain/stock/model/StockRank.java
@@ -1,0 +1,81 @@
+package com.fintory.domain.stock.model;
+
+import com.fintory.domain.common.BaseEntity;
+import com.fintory.domain.stock.dto.EODResponse;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+
+@Entity
+@Builder
+@AllArgsConstructor
+@Getter
+@Table(name="stock_rank")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StockRank extends BaseEntity {
+
+    @Column(name="roc_rank")
+    private int rocRank;
+
+    @Column(name="trading_volume_rank")
+    private int tradingVolumeRank;
+
+    @Column(name="market_cap_rank")
+    private int marketCapRank;
+
+    @Column(name="market_cap")
+    private BigDecimal marketCap;
+
+    @Column(name="roc_rate")
+    private BigDecimal rocRate;
+
+    @Column(name="trading_volume")
+    private double tradingVolume;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="stock_id")
+    private Stock stock;
+
+
+    public StockRank updateVolumeStockRank(int tradingVolumeRank) {
+        this.tradingVolumeRank=tradingVolumeRank;
+        return this;
+    }
+
+    public StockRank updateROCStockRank(int rocRank) {
+        this.rocRank=rocRank;
+        return this;
+    }
+
+    public StockRank updateVolumeAndROC(List<EODResponse> response) {
+            // 최신 데이터 (인덱스 0)와 이전 데이터 (인덱스 1)
+            EODResponse today = response.get(0);
+            EODResponse yesterday = response.get(1);
+
+            // 거래량
+            double volume = today.volume();
+
+            // 등락률 계산: (오늘 종가 - 어제 종가) / 어제 종가 * 100
+            BigDecimal todayClose = today.close();
+            BigDecimal yesterdayClose = yesterday.close();
+
+            BigDecimal rocRate = null;
+            if (todayClose != null && yesterdayClose != null &&
+                    yesterdayClose.compareTo(BigDecimal.ZERO) != 0) {
+
+                rocRate= todayClose.subtract(yesterdayClose)
+                        .divide(yesterdayClose, 6, RoundingMode.HALF_UP)
+                        .multiply(BigDecimal.valueOf(100));
+            }
+
+            this.rocRate = rocRate;
+            this.tradingVolume = volume;
+
+        return this;
+    }
+
+
+}

--- a/domain/src/main/java/com/fintory/domain/stock/service/StockPriceHistoryService.java
+++ b/domain/src/main/java/com/fintory/domain/stock/service/StockPriceHistoryService.java
@@ -1,0 +1,29 @@
+package com.fintory.domain.stock.service;
+
+import com.fintory.domain.stock.dto.IntraDayResponse;
+import com.fintory.domain.stock.dto.StockPriceHistoryWrapper;
+import com.fintory.domain.stock.model.IntervalType;
+import com.fintory.domain.stock.model.Stock;
+
+import java.util.List;
+
+public interface StockPriceHistoryService {
+
+    /**
+     *
+     * MarketStack API를 통해 모든 Interval(weekly,monthly,yearly,fiveyearly,total)에 해당하는 시세 데이터를 StockPriceHistory에 저장하는 메소드
+     *
+     */
+     void getAllIntraDay();
+
+    /**
+     *
+     * 기간별 시세를 저장하는 템플릿 메소드
+     *
+     * @param dataList MarketStack API로부터 받은 기간별 시세 데이터
+     * @param stock 주식
+     * @param intervalType weekly, monthly, yearly, fiveyearly, total
+     */
+     void updateIntervalData(List<IntraDayResponse> dataList, Stock stock, IntervalType intervalType);
+
+}

--- a/infra/build.gradle
+++ b/infra/build.gradle
@@ -59,6 +59,9 @@ dependencies {
     /* swagger */
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8")
 
+    /* Jackson */
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'
 }

--- a/infra/src/main/java/com/fintory/infra/domain/stock/config/HttpClientConfig.java
+++ b/infra/src/main/java/com/fintory/infra/domain/stock/config/HttpClientConfig.java
@@ -1,0 +1,20 @@
+package com.fintory.infra.domain.stock.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class HttpClientConfig {
+
+    /**
+     *
+     *TODO 초기에는 API 호출과 DB 저장 작업을 비동기로 처리하려 했으나,
+     * 스레드 간 전환 시 트랜잭션 컨텍스트 유실과 데이터 원자성 보장 문제로 인해 동기 방식으로 변경.
+     * "데이터 가져오기 + DB 저장"을 하나의 원자적 작업 단위로 보장하기 위해 같은 스레드에서 순차 처리함.
+     */
+    @Bean
+    public RestTemplate restTemplate(){
+        return new RestTemplate();
+    }
+}

--- a/infra/src/main/java/com/fintory/infra/domain/stock/repository/LiveStockPriceRepository.java
+++ b/infra/src/main/java/com/fintory/infra/domain/stock/repository/LiveStockPriceRepository.java
@@ -1,0 +1,15 @@
+package com.fintory.infra.domain.stock.repository;
+
+import com.fintory.domain.stock.model.LiveStockPrice;
+import com.fintory.domain.stock.model.Stock;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface LiveStockPriceRepository extends JpaRepository<LiveStockPrice,Long> {
+
+    @Query("SELECT lsp FROM LiveStockPrice lsp JOIN FETCH lsp.stock WHERE lsp.stock=:stock")
+    Optional<LiveStockPrice> findByStock(@Param("stock") Stock stock);
+}

--- a/infra/src/main/java/com/fintory/infra/domain/stock/repository/StockPriceHistoryRepository.java
+++ b/infra/src/main/java/com/fintory/infra/domain/stock/repository/StockPriceHistoryRepository.java
@@ -1,0 +1,20 @@
+package com.fintory.infra.domain.stock.repository;
+
+import com.fintory.domain.stock.model.IntervalType;
+import com.fintory.domain.stock.model.Stock;
+import com.fintory.domain.stock.model.StockPriceHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import java.util.List;
+
+@Repository
+public interface StockPriceHistoryRepository extends JpaRepository<StockPriceHistory,Long> {
+    void deleteByStock(Stock stock);
+
+    void deleteByStockAndIntervalType(Stock stock, IntervalType intervalType);
+
+    @Query("SELECT sph FROM StockPriceHistory sph JOIN FETCH sph.stock WHERE sph.stock=:stock")
+    List<StockPriceHistory> findByStock(@Param("stock") Stock stock);
+}

--- a/infra/src/main/java/com/fintory/infra/domain/stock/repository/StockRankRepository.java
+++ b/infra/src/main/java/com/fintory/infra/domain/stock/repository/StockRankRepository.java
@@ -1,0 +1,27 @@
+package com.fintory.infra.domain.stock.repository;
+
+import com.fintory.domain.stock.model.Stock;
+import com.fintory.domain.stock.model.StockRank;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface StockRankRepository extends JpaRepository<StockRank,Long> {
+    @Query("SELECT sr FROM StockRank sr JOIN FETCH sr.stock WHERE sr.stock = :stock")
+    Optional<StockRank> findByStock(@Param("stock") Stock stock);
+
+    @Query("SELECT sr FROM StockRank sr JOIN FETCH sr.stock WHERE sr.stock.currencyName = :currencyName ORDER BY sr.marketCapRank ASC")
+    List<StockRank> findMarketCapTop20(@Param("currencyName") String currencyName);
+
+    @Query("SELECT sr FROM StockRank sr JOIN FETCH sr.stock WHERE sr.stock.currencyName = :currencyName ORDER BY sr.rocRank ASC")
+    List<StockRank> findROCTop20(@Param("currencyName") String currencyName);
+
+    @Query("SELECT sr FROM StockRank sr JOIN FETCH sr.stock WHERE sr.stock.currencyName = :currencyName ORDER BY sr.tradingVolumeRank ASC")
+    List<StockRank> findTradingVolumeTop20(@Param("currencyName") String currencyName);
+
+    @Query("SELECT sr FROM StockRank sr JOIN FETCH sr.stock WHERE sr.stock.currencyName = :currencyName")
+    List<StockRank> findByCurrencyName(@Param("currencyName") String currencyName);
+}

--- a/infra/src/main/java/com/fintory/infra/domain/stock/repository/StockRepository.java
+++ b/infra/src/main/java/com/fintory/infra/domain/stock/repository/StockRepository.java
@@ -1,0 +1,20 @@
+package com.fintory.infra.domain.stock.repository;
+
+import com.fintory.domain.stock.model.Stock;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface StockRepository extends JpaRepository<Stock,Long> {
+    List<Stock> findByCurrencyName(String currencyName);
+
+    Optional<Stock> findByCode(String stockCode);
+
+    @Query("SELECT s FROM Stock s Where s.name LIKE CONCAT('%',:keyword,'%') OR s.code LIKE CONCAT('%',:keyword,'%') OR s.eng_name LIKE CONCAT('%',:keyword,'%')")
+    List<Stock> findByNameContainingOrCodeContaining(@Param("keyword") String keyword);
+}

--- a/infra/src/main/java/com/fintory/infra/domain/stock/service/EODataServiceImpl.java
+++ b/infra/src/main/java/com/fintory/infra/domain/stock/service/EODataServiceImpl.java
@@ -1,0 +1,209 @@
+package com.fintory.infra.domain.stock.service;
+
+import com.fintory.common.exception.DomainErrorCode;
+import com.fintory.common.exception.DomainException;
+import com.fintory.domain.stock.dto.EODResponse;
+import com.fintory.domain.stock.dto.EODResponseWrapper;
+import com.fintory.domain.stock.model.LiveStockPrice;
+import com.fintory.domain.stock.model.Stock;
+import com.fintory.domain.stock.model.StockRank;
+import com.fintory.domain.stock.service.StockDataService;
+import com.fintory.infra.domain.stock.repository.LiveStockPriceRepository;
+import com.fintory.infra.domain.stock.repository.StockRankRepository;
+import com.fintory.infra.domain.stock.repository.StockRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/*
+REVIEW EOD 데이터를 이용해서 DB에 값을 저장한다는 점에서 StockRank와 LiveStockPrice를 같은 클래스 내에 위치시킴.
+    (EOD 데이터를 받아오면 -> LiveStockPrice, StockRank를 바로 저장하기 위해서)
+* */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class EODataServiceImpl implements StockDataService {
+
+    private final RestTemplate restTemplate;
+    private final StockRepository stockRepository;
+    private final LiveStockPriceRepository liveStockPriceRepository;
+    private final StockRankRepository stockRankRepository;
+
+    @Value("${market-stack.access-key}")
+    private String accessKey;
+
+    //최초 초기화 함수
+    @Override
+    public void getAllEOD() {
+        try {
+            String stockCodes = getStockCodes();
+            EODResponseWrapper wrapper = fetchEODData(stockCodes);
+            processStockData(wrapper);
+            //REVIEW API를 사용 시 발생할 수 있는 에러들이 많아서(Doc에 명시됨) 광범위하게 범위를 결정함 -> 좋은 방법 찾아보기.
+        } catch (Exception e) {
+            log.error("EOD 조회 중 에러 발생: {}", e);
+            throw new DomainException(DomainErrorCode.API_FAILED);
+        }
+    }
+
+    //WARN 시가 총액의 경우 -> 현재 사용하는 API 등급으로는 접근할 수 없음. 그러나 현재 주식 종목들의 시가총액의 변동성이 크지 않은 점을 고려하여(인기 종목 20개씩) 시가총액은 주식 데이터와 함께 "미리" 저장되는 구조로 진행함.
+    //거래량, 전일대비 등락률을 보고 rank 결정
+    @Override
+    @Transactional
+    public void saveAllRank(){
+        //국내와 해외 데이터는 순위를 다르게 지정하기 위해서 각각 저장.
+        List<StockRank> koreanStockRankList =  stockRankRepository.findByCurrencyName("KRW");
+        List<StockRank> overseasStockRankList =  stockRankRepository.findByCurrencyName("USD");
+
+        saveEachRank(koreanStockRankList);
+        saveEachRank(overseasStockRankList);
+    }
+
+    private void saveEachRank(List<StockRank> stockRankList){
+        //거래량 순위 저장
+        AtomicInteger volume = new AtomicInteger(1);
+        stockRankList.stream()
+                .sorted(Comparator.comparing(StockRank::getTradingVolume).reversed()
+                        .thenComparing(StockRank::getMarketCap))// 값이 동일하면 시가 총액으로 순위 결정
+                .forEach(rank ->{
+                    rank.updateVolumeStockRank(volume.getAndIncrement());
+                });
+
+        // 등락률 순위 저장
+        AtomicInteger roc =new AtomicInteger(1);
+        stockRankList.stream()
+                .sorted(Comparator.comparing((StockRank rank)-> rank.getRocRate().abs()).reversed()
+                        .thenComparing(StockRank::getMarketCapRank)) // 값이 동일하면 시가 총액으로 순위 결정
+                .forEach(rank->{
+                    rank.updateROCStockRank(roc.getAndIncrement());
+                });
+
+        stockRankRepository.saveAll(stockRankList);
+    }
+
+    // 전체 주식 코드 조회
+    // 개별 API 요청이 아닌 한번에 보내기 위해 주식 code를 처리하는 로직( ex) AAPL,GOOGL....)
+    private String getStockCodes() {
+        List<Stock> koreanList = stockRepository.findByCurrencyName("KRW");
+        List<Stock> overseasList = stockRepository.findByCurrencyName("USD");
+
+        return Stream.concat(koreanList.stream(), overseasList.stream())
+                .map(Stock::getCode)
+                .collect(Collectors.joining(","));
+    }
+
+    // RestTemplate을 통한 MarketStack API 서버와 통신하는 메소드
+    private EODResponseWrapper fetchEODData(String symbols) {
+        LocalDate today = LocalDate.now();
+        LocalDate yesterday = today.minusDays(4); // 장이 열리지 않는 날을 고려하여 여유 있는 날짜 범위 선택
+
+        String url = UriComponentsBuilder.fromUriString("http://api.marketstack.com/v1/eod")
+                .queryParam("access_key", accessKey)
+                .queryParam("symbols", symbols)
+                .queryParam("sort", "DESC")
+                .queryParam("date_from", yesterday)
+                .queryParam("date_to", today)
+                .toUriString();
+
+        EODResponseWrapper wrapper = restTemplate.getForObject(url, EODResponseWrapper.class);
+
+        if (wrapper == null) {
+            throw new DomainException(DomainErrorCode.API_RESPONSE_NULL);
+        }
+
+        return wrapper;
+    }
+
+    // EOD API를 통해 받은 데이터를 liveStockPrice, StockRank Entity에 저장하는 통합 메소드
+    // NOTE 해당 기능을 구현할 구현체도 없고 다른 모듈에서도 사용하지 않지만 같은 트랜잭션을 보장하기 위해 public으로 설정함(인터페이스에선 없음 참고)
+    @Transactional
+    public void processStockData(EODResponseWrapper wrapper) {
+        if (wrapper == null || wrapper.eodResponseList() == null || wrapper.eodResponseList().isEmpty()) {
+            log.warn("API 응답이 비어있어서 처리를 건너뜀");
+            return;
+        }
+
+        updateLiveStockPrices(wrapper);
+        updateStockRanks(wrapper);
+    }
+
+    private void updateLiveStockPrices(EODResponseWrapper wrapper) {
+        List<Stock> stockList = stockRepository.findAll();
+
+        //미리 주식별로 그룹핑 -> for문 개선
+        Map<String,List<EODResponse>> responseMap = wrapper.eodResponseList().stream()
+                .collect(Collectors.groupingBy(EODResponse::symbol));
+
+        for (Stock stock : stockList) {
+            List<EODResponse> stockResponse = responseMap.getOrDefault(stock.getCode(),List.of());
+
+            if (stockResponse.size() >= 2) {
+                saveEachLiveStockPrice(stockResponse, stock);
+            } else {
+                log.warn("주식 {} - 데이터 부족으로 LiveStockPrice 업데이트 건너뜀 (받은 데이터: {}개)",
+                        stock.getCode(), stockResponse.size());
+                //TODO 데이터가 2개 미만이라고 에러를 던지진 않음 -> 일단 현재 서버는 이전 서버와는 달리 에러를 거의 던지지 않고,
+                //  만약 데이터를 못가져왔다고 해도 DB에서 이전에 저장된 데이터를 보여주면 되니까. -> 해당 방법 고민해보기
+            }
+        }
+    }
+
+    private void updateStockRanks(EODResponseWrapper wrapper) {
+        List<StockRank> stockRankList = stockRankRepository.findAll();
+
+        for (StockRank rank : stockRankList) {
+            List<EODResponse> stockResponse = wrapper.eodResponseList().stream()
+                    .filter(response -> response.symbol().equals(rank.getStock().getCode()))
+                    .toList();
+
+            if (stockResponse.size() >= 2) {
+                saveStockRankData(stockResponse, rank.getStock());
+            } else {
+                log.warn("주식 {} - 데이터 부족으로 StockRank 업데이트 건너뜀 (받은 데이터: {}개)",
+                        rank.getStock().getCode(), stockResponse.size());
+            }
+        }
+    }
+
+    // 개별 LiveStockPrice 데이터 저장하는 메소드
+    private void saveEachLiveStockPrice(List<EODResponse> response,Stock stock){
+        LiveStockPrice existing = liveStockPriceRepository.findByStock(stock)
+                .orElseGet(()->
+                        LiveStockPrice.builder()
+                                .stock(stock)
+                                .currentPrice(BigDecimal.ZERO)
+                                .priceChange(BigDecimal.ZERO)
+                                .priceChangeRate(BigDecimal.ZERO)
+                                .build());
+
+        existing.updateLiveStockPrice(response);
+
+        liveStockPriceRepository.save(existing);
+    }
+
+    //개별 StockRank 데이터 저장하는 메소드
+    private void saveStockRankData(List<EODResponse> response,Stock stock){
+        StockRank existing = stockRankRepository.findByStock(stock)
+                .orElseGet(()->
+                        StockRank.builder()
+                                .stock(stock)
+                                .build());
+
+        existing.updateVolumeAndROC(response);
+
+        stockRankRepository.save(existing);
+    }
+}

--- a/infra/src/main/java/com/fintory/infra/domain/stock/service/StockPriceHistoryScheduler.java
+++ b/infra/src/main/java/com/fintory/infra/domain/stock/service/StockPriceHistoryScheduler.java
@@ -1,0 +1,108 @@
+package com.fintory.infra.domain.stock.service;
+
+import com.fintory.common.exception.DomainErrorCode;
+import com.fintory.common.exception.DomainException;
+import com.fintory.domain.stock.dto.IntraDayResponse;
+import com.fintory.domain.stock.model.IntervalType;
+import com.fintory.domain.stock.model.Stock;
+import com.fintory.infra.domain.stock.repository.StockRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class StockPriceHistoryScheduler {
+    private final StockPriceHistoryServiceImpl intraDayService;
+    private final StockRepository stockRepository;
+
+    // 1. 매일 새벽 1시 - 단기 데이터 (weekly, monthly)
+    @Scheduled(cron = "0 0 1 * * *")
+    @Transactional
+    public void updateShortTermData() {
+        log.info("단기 데이터 업데이트 시작 (weekly, monthly)");
+        try {
+            List<Stock> allStocks = stockRepository.findAll();
+            for (Stock stock : allStocks) {
+                List<IntraDayResponse> weeklyData = intraDayService.fetchIntraDayDataByWeek(stock.getCode());
+                intraDayService.updateIntervalData(weeklyData, stock, IntervalType.WEEKLY);
+
+                List<IntraDayResponse> monthlyData = intraDayService.fetchIntraDayDataByMonth(stock.getCode());
+                intraDayService.updateIntervalData(monthlyData, stock, IntervalType.MONTHLY);
+                // API 제한 방지용 딜레이
+                Thread.sleep(200); // 0.2초 대기
+            }
+            log.info("단기 데이터 업데이트 완료");
+        } catch (Exception e) {
+            log.error("단기 데이터 업데이트 중 오류: {}", e.getMessage());
+            throw new DomainException(DomainErrorCode.API_FAILED);
+        }
+    }
+
+    // 2. 매월 1일 새벽 2시 - 1년 데이터 (월별 12개 포인트)
+    @Scheduled(cron = "0 0 2 1 * *")
+    @Transactional
+    public void updateYearlyData() {
+        log.info("연간 데이터 업데이트 시작");
+        try {
+            List<Stock> allStocks = stockRepository.findAll();
+            for (Stock stock : allStocks) {
+                List<IntraDayResponse> yearlyData = intraDayService.fetchIntraDayDataByYear(stock.getCode());
+                intraDayService.updateIntervalData(yearlyData, stock, IntervalType.YEARLY);
+                Thread.sleep(300); // 0.3초 대기
+            }
+            log.info("연간 데이터 업데이트 완료");
+        } catch (Exception e) {
+            log.error("연간 데이터 업데이트 중 오류: {}", e.getMessage(), e);
+            throw new DomainException(DomainErrorCode.API_FAILED);
+        }
+    }
+
+    // 3. 매년 1월 1일 새벽 3시 - 5년 데이터 (연별 5개 포인트)
+    @Scheduled(cron = "0 0 3 1 1 *")
+    @Transactional
+    public void updateFiveYearData() {
+        log.info("5년 데이터 업데이트 시작");
+        try {
+            List<Stock> allStocks = stockRepository.findAll();
+            for (Stock stock : allStocks) {
+                List<IntraDayResponse> fiveYearData = intraDayService.fetchIntraDayDataBy5Year(stock.getCode());
+                intraDayService.updateIntervalData(fiveYearData, stock, IntervalType.FIVEYEARLY);
+                Thread.sleep(250); // 0.25초 대기
+            }
+            log.info("5년 데이터 업데이트 완료");
+
+        } catch (Exception e) {
+            log.error("5년 데이터 업데이트 중 오류: {}", e.getMessage(), e);
+            throw new DomainException(DomainErrorCode.API_FAILED);
+
+        }
+    }
+
+    // 4. 매년 1월 1일 새벽 4시 - 전체 데이터 (연별 15개 포인트)
+    @Scheduled(cron = "0 0 4 1 1 *")
+    @Transactional
+    public void updateTotalData() {
+        log.info("전체 데이터 업데이트 시작 (15년)");
+        try {
+            List<Stock> allStocks = stockRepository.findAll();
+
+            for (Stock stock : allStocks) {
+                List<IntraDayResponse> totalData = intraDayService.fetchIntraDayDataByTotal(stock.getCode());
+                intraDayService.updateIntervalData(totalData, stock, IntervalType.TOTAL);
+
+                Thread.sleep(250); // 0.25초 대기 (15번 호출)
+            }
+            log.info("전체 데이터 업데이트 완료");
+
+        } catch (Exception e) {
+            log.error("전체 데이터 업데이트 중 오류: {}", e.getMessage(), e);
+            throw new DomainException(DomainErrorCode.API_FAILED);
+        }
+    }
+}

--- a/infra/src/main/java/com/fintory/infra/domain/stock/service/StockPriceHistoryServiceImpl.java
+++ b/infra/src/main/java/com/fintory/infra/domain/stock/service/StockPriceHistoryServiceImpl.java
@@ -1,0 +1,291 @@
+package com.fintory.infra.domain.stock.service;
+
+import com.fintory.common.exception.DomainErrorCode;
+import com.fintory.common.exception.DomainException;
+import com.fintory.domain.stock.dto.IntraDayResponse;
+import com.fintory.domain.stock.dto.IntraDayResponseWrapper;
+import com.fintory.domain.stock.model.IntervalType;
+import com.fintory.domain.stock.model.Stock;
+import com.fintory.domain.stock.model.StockPriceHistory;
+import com.fintory.domain.stock.service.StockPriceHistoryService;
+import com.fintory.infra.domain.stock.repository.StockPriceHistoryRepository;
+import com.fintory.infra.domain.stock.repository.StockRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+//TODO 일 데이터 -> 웹소켓으로 저장하고 보여주기.(분단위 현재가 데이터를 얻어올 수 없음(국내 주식))
+/*
+
+    TODO 각 기간별 시세 데이터를 가져올 떄 -> 중복되는 데이터가 있을 수 있음. 차라리 한번에 가져와서 처리를 해볼까 고민을 했지만
+     15년치 데이터에서 개별 기간(주/월/년)을 조절하면서 가져온 후 데이터를 처리하는 것보다는 각각의 API에게 요청하는 방법 선택  -> 더 좋은 방법이 있는지 고민
+
+ */
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class StockPriceHistoryServiceImpl implements StockPriceHistoryService {
+    private final RestTemplate restTemplate;
+    private final StockRepository stockRepository;
+    private final StockPriceHistoryRepository stockPriceHistoryRepository;
+
+    @Value("${market-stack.access-key}")
+    private String accessKey;
+
+    //REVIEW 데이터가 적다고 판단될 시 늘릴 예정
+    /**
+     * weekly -> 7개 이하
+     * monthly -> 30개 이하
+     * yearly -> 12개 이하
+     * fiveyearly -> 5개 이하
+     * total -> 15개 이하
+     */
+
+    //최초 실행용
+    //NOTE 과도한 API 요청을 사용하므로 해당 함수는 데이터베이스가 없을 때만 사용 주의
+    @Override
+    @Transactional
+    public void getAllIntraDay() {
+        try {
+            List<Stock> allStocks = stockRepository.findAll(); // 모든 주식 조회
+
+            //REVIEW for문을 돌리지만, 에러가 발생한다면 개별 종목이 아닌 전체적인 에러가 발생한 것이라서 다음과 같이 처리
+            for (Stock stock : allStocks) {
+                String stockCode = stock.getCode();
+                Map<String, Object> response = fetchIntraDayData(stockCode); // 전체 IntervalType의 기간별 시세 데이터를 가져옴
+                processStockData(response, stock); //liveStockPrice, stockRank 저장
+            }
+        } catch (Exception e) {
+            log.error("EOD 조회 중 에러 발생: {}", e.getMessage());
+            throw new DomainException(DomainErrorCode.API_FAILED);
+        }
+    }
+
+
+    // 모은 데이터들을 intervalType과 함께 통합 저장
+    private Map<String, Object> fetchIntraDayData(String stockCodes) {
+        Map<String, Object> intraResponse = new HashMap<>();
+
+        intraResponse.put("WEEKLY", fetchIntraDayDataByWeek(stockCodes));
+        intraResponse.put("MONTHLY", fetchIntraDayDataByMonth(stockCodes));
+        intraResponse.put("YEARLY", fetchIntraDayDataByYear(stockCodes));
+        intraResponse.put("FIVEYEARLY", fetchIntraDayDataBy5Year(stockCodes));
+        intraResponse.put("TOTAL", fetchIntraDayDataByTotal(stockCodes));
+
+        return intraResponse;
+    }
+
+
+    //API로부터 받은 데이터로 DB 초기화
+    private void processStockData(Map<String, Object> response, Stock stock) {
+
+        stockPriceHistoryRepository.deleteByStock(stock);
+
+        List<StockPriceHistory> historyList = new ArrayList<>();
+
+        if(response!=null && !response.isEmpty()) {
+            for (Map.Entry<String, Object> entry : response.entrySet()) {
+                String intervalKey = entry.getKey();
+
+                List<IntraDayResponse> dataList = (List<IntraDayResponse>) entry.getValue();
+
+                for (IntraDayResponse data : dataList) {
+                    StockPriceHistory history = StockPriceHistory.builder()
+                            .stock(stock)
+                            .highPrice(data.high())
+                            .closePrice(data.close())
+                            .openPrice(data.open())
+                            .lowPrice(data.low())
+                            .intervalType(mapIntoIntervalType(intervalKey))
+                            .date(data.date())
+                            .build();
+
+                    historyList.add(history);
+                }
+            }
+        }else{
+            log.warn("주식 {} 데이터가 비어있음", stock.getCode());
+        }
+        if (!historyList.isEmpty()) {
+            stockPriceHistoryRepository.saveAll(historyList);
+        }
+    }
+
+    // 주별 시세 데이터 -> 최대 7개 데이터
+    protected List<IntraDayResponse> fetchIntraDayDataByWeek(String symbols) {
+        LocalDate today = LocalDate.now();
+        LocalDate lastWeek = LocalDate.now().minusDays(7);
+
+        String url = UriComponentsBuilder.fromUriString("http://api.marketstack.com/v2/eod")
+                .queryParam("access_key", accessKey)
+                .queryParam("symbols", symbols)
+                .queryParam("sort", "DESC")
+                .queryParam("date_from", lastWeek)
+                .queryParam("date_to", today)
+                .toUriString();
+        IntraDayResponseWrapper wrapper = restTemplate.getForObject(url, IntraDayResponseWrapper.class);
+        return wrapper.intraDayResponseList();
+    }
+
+
+    //월별 시세 데이터 -> 최대 30개 데이터
+    protected List<IntraDayResponse> fetchIntraDayDataByMonth(String symbols) {
+        LocalDate today = LocalDate.now();
+        LocalDate lastMonth = LocalDate.now().minusDays(30);
+
+        String url = UriComponentsBuilder.fromUriString("http://api.marketstack.com/v2/eod")
+                .queryParam("access_key", accessKey)
+                .queryParam("symbols", symbols)
+                .queryParam("sort", "DESC")
+                .queryParam("date_from", lastMonth)
+                .queryParam("date_to", today)
+                .toUriString();
+        IntraDayResponseWrapper wrapper = restTemplate.getForObject(url, IntraDayResponseWrapper.class);
+        return wrapper.intraDayResponseList();
+    }
+
+
+    /* interval_type을 지정할 수 없어서 하루 단위로만 데이터를 가져올 수 있음 -> 구간별로 나누어서 딱 1개의 데이터만 요청(변경 가능. 지금은 API 호출량을 줄이기 위함이였음)  */
+
+
+    //1년 시세 데이터 -> 최대 12개
+    protected List<IntraDayResponse> fetchIntraDayDataByYear(String symbols) {
+        List<IntraDayResponse> result = new ArrayList<>();
+        LocalDate today = LocalDate.now();
+
+        //1년을 12구간으로 나눔 -> 월별 데이터
+        for (int i = 0; i < 12; i++) {
+            LocalDate targetDate = today.minusMonths(i);
+
+            String url = UriComponentsBuilder.fromUriString("http://api.marketstack.com/v2/eod")
+                    .queryParam("access_key", accessKey)
+                    .queryParam("symbols", symbols)
+                    .queryParam("sort", "DESC")
+                    .queryParam("date_from", targetDate.minusDays(3)) //주말 대비 여유
+                    .queryParam("date_to", targetDate)
+                    .queryParam("limit", "1") //딱 1개만
+                    .toUriString();
+
+            IntraDayResponseWrapper wrapper = restTemplate.getForObject(url, IntraDayResponseWrapper.class);
+            if (!wrapper.intraDayResponseList().isEmpty()) {
+                result.add(wrapper.intraDayResponseList().get(0));
+            }
+        }
+
+        return result;
+    }
+
+    //5년 시세 데이터 -> 최대 5개
+    protected List<IntraDayResponse> fetchIntraDayDataBy5Year(String symbols) {
+        List<IntraDayResponse> result = new ArrayList<>();
+        LocalDate today = LocalDate.now();
+
+        //5년을 5구간으로 나눔 -> 년도별 데이터
+        for (int i = 0; i < 5; i++) {
+            LocalDate targetDate = today.minusYears(i);
+
+            String url = UriComponentsBuilder.fromUriString("http://api.marketstack.com/v2/eod")
+                    .queryParam("access_key", accessKey)
+                    .queryParam("symbols", symbols)
+                    .queryParam("sort", "DESC")
+                    .queryParam("date_from", targetDate.minusDays(5)) //주말 대비 여유
+                    .queryParam("date_to", targetDate)
+                    .queryParam("limit", "1") //딱 1개만
+                    .toUriString();
+
+            IntraDayResponseWrapper wrapper = restTemplate.getForObject(url, IntraDayResponseWrapper.class);
+            if (!wrapper.intraDayResponseList().isEmpty()) {
+                result.add(wrapper.intraDayResponseList().get(0));
+            }
+        }
+
+        return result;
+    }
+
+
+    //15년 시세 데이터 -> 최대 15개
+    protected List<IntraDayResponse> fetchIntraDayDataByTotal(String symbols) {
+        List<IntraDayResponse> result = new ArrayList<>();
+        LocalDate today = LocalDate.now();
+
+        //15년을 15구간으로 나누기 -> 년도별 데이터
+        for (int i = 0; i < 15; i++) {
+            LocalDate targetDate = today.minusYears(i);
+
+            String url = UriComponentsBuilder.fromUriString("http://api.marketstack.com/v2/eod")
+                    .queryParam("access_key", accessKey)
+                    .queryParam("symbols", symbols)
+                    .queryParam("sort", "DESC")
+                    .queryParam("date_from", targetDate.minusDays(7)) //주말 대비 여유
+                    .queryParam("date_to", targetDate)
+                    .queryParam("limit", "1") //딱 1개만
+                    .toUriString();
+
+            IntraDayResponseWrapper wrapper = restTemplate.getForObject(url, IntraDayResponseWrapper.class);
+            if (!wrapper.intraDayResponseList().isEmpty()) {
+                result.add(wrapper.intraDayResponseList().get(0));
+            }
+        }
+
+        return result;
+    }
+
+
+    // 기간별 시세 저장 메소드 템플릿
+    @Override
+    public void updateIntervalData(List<IntraDayResponse> dataList, Stock stock, IntervalType intervalType) {
+
+            // 기존 해당 기간 데이터 삭제
+            stockPriceHistoryRepository.deleteByStockAndIntervalType(stock, intervalType);
+
+            // 새 데이터 저장
+            if (dataList != null && !dataList.isEmpty()) {
+                List<StockPriceHistory> historyList = new ArrayList<>();
+
+                for (IntraDayResponse data : dataList) {
+                    StockPriceHistory history = StockPriceHistory.builder()
+                            .stock(stock)
+                            .highPrice(data.high())
+                            .closePrice(data.close())
+                            .openPrice(data.open())
+                            .lowPrice(data.low())
+                            .intervalType(intervalType)
+                            .date(data.date())
+                            .build();
+                    historyList.add(history);
+                }
+
+                stockPriceHistoryRepository.saveAll(historyList);
+            } else {
+                log.warn("주식 {} - {} 데이터가 비어있음", stock.getCode(), intervalType);
+            }
+    }
+
+
+    // IntervalType 매핑
+    public IntervalType mapIntoIntervalType(String interval){
+        return switch (interval.toUpperCase()) {
+            case "WEEKLY"->IntervalType.WEEKLY;
+            case "MONTHLY"->IntervalType.MONTHLY;
+            case "YEARLY"->IntervalType.YEARLY;
+            case "FIVEYEARLY"->IntervalType.FIVEYEARLY;
+            case "TOTAL"->IntervalType.TOTAL;
+            default ->{
+                log.error("알 수 없는 intervalType:{}", interval);
+                yield IntervalType.WEEKLY;
+            }
+        };
+    }
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #27 

## 📝작업 내용

- 기간별 시세 데이터 조회 및 저장
- 순위 생성을 위한 데이터 조회
- 순위 생성 및 관련 데이터 저장
- End-of-Day Data 조회 > 현재가 데이터 저장



## 💬리뷰 요구사항(선택)

- 리뷰할 파일이 많을 것 같아서 지금은 시세 데이터 + 기간별 시세 데이터 관련 기능만 push했습니다!
- 저번 PR때 리뷰해주신 내용들 정말 도움 많이 되었습니다! 거의 대부분 반영했습니다! 답글을 적었다가 새로운 기능으로 변경하느라 제출을 안해서요! 혹시 답글 필요하시면 말씀해주세요! 감사했습니다~ 
