### PR TITLE
출석 체크 api

### DIFF
--- a/app-child/src/main/java/com/fintory/child/domain/attendance/controller/AttendanceController.java
+++ b/app-child/src/main/java/com/fintory/child/domain/attendance/controller/AttendanceController.java
@@ -1,0 +1,15 @@
+package com.fintory.child.domain.attendance.controller;
+
+import com.fintory.auth.util.CustomUserDetails;
+import com.fintory.common.api.ApiResponse;
+import com.fintory.domain.attendence.dto.AttendanceLogResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.util.List;
+
+public interface AttendanceController {
+
+    ResponseEntity<ApiResponse<Integer>> attendanceCheck(@AuthenticationPrincipal CustomUserDetails user);
+    ResponseEntity<ApiResponse<List<AttendanceLogResponse>>> getAttendanceList();
+}

--- a/app-child/src/main/java/com/fintory/child/domain/attendance/controller/AttendanceController.java
+++ b/app-child/src/main/java/com/fintory/child/domain/attendance/controller/AttendanceController.java
@@ -3,13 +3,21 @@ package com.fintory.child.domain.attendance.controller;
 import com.fintory.auth.util.CustomUserDetails;
 import com.fintory.common.api.ApiResponse;
 import com.fintory.domain.attendence.dto.AttendanceLogResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
 import java.util.List;
 
+@Tag(name = "출석 체크 API")
 public interface AttendanceController {
 
+    @Operation(summary = "출석 체크 및 연속 출석일 수 반환")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "연속 출석일 반환")
     ResponseEntity<ApiResponse<Integer>> attendanceCheck(@AuthenticationPrincipal CustomUserDetails user);
-    ResponseEntity<ApiResponse<List<AttendanceLogResponse>>> getAttendanceList();
+
+    @Operation(summary = "출석일 전체 리스트 반환")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "출석 리스트 반환(LocalDate형)")
+    ResponseEntity<ApiResponse<List<AttendanceLogResponse>>> getAttendanceList(@AuthenticationPrincipal CustomUserDetails user);
 }

--- a/app-child/src/main/java/com/fintory/child/domain/attendance/controller/AttendanceControllerImpl.java
+++ b/app-child/src/main/java/com/fintory/child/domain/attendance/controller/AttendanceControllerImpl.java
@@ -34,7 +34,7 @@ public class AttendanceControllerImpl implements AttendanceController{
 
     @Override
     @GetMapping("/attendance-log")
-    public ResponseEntity<ApiResponse<List<AttendanceLogResponse>>> getAttendanceList() {
+    public ResponseEntity<ApiResponse<List<AttendanceLogResponse>>> getAttendanceList(@AuthenticationPrincipal CustomUserDetails user) {
         return null;
     }
 }

--- a/app-child/src/main/java/com/fintory/child/domain/attendance/controller/AttendanceControllerImpl.java
+++ b/app-child/src/main/java/com/fintory/child/domain/attendance/controller/AttendanceControllerImpl.java
@@ -33,8 +33,10 @@ public class AttendanceControllerImpl implements AttendanceController{
     }
 
     @Override
-    @GetMapping("/attendance-log")
+    @GetMapping("/attendance-logs")
     public ResponseEntity<ApiResponse<List<AttendanceLogResponse>>> getAttendanceList(@AuthenticationPrincipal CustomUserDetails user) {
-        return null;
+        Child child = childService.getChild(user.getUsername());
+        List<AttendanceLogResponse> logs = attendanceService.getAttendanceLogs(child);
+        return ResponseEntity.ok(ApiResponse.ok(logs));
     }
 }

--- a/app-child/src/main/java/com/fintory/child/domain/attendance/controller/AttendanceControllerImpl.java
+++ b/app-child/src/main/java/com/fintory/child/domain/attendance/controller/AttendanceControllerImpl.java
@@ -1,0 +1,40 @@
+package com.fintory.child.domain.attendance.controller;
+
+import com.fintory.auth.util.CustomUserDetails;
+import com.fintory.common.api.ApiResponse;
+import com.fintory.domain.attendence.dto.AttendanceLogResponse;
+import com.fintory.domain.attendence.service.AttendanceService;
+import com.fintory.domain.child.model.Child;
+import com.fintory.domain.child.service.ChildService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/child/attendance")
+public class AttendanceControllerImpl implements AttendanceController{
+
+    private final AttendanceService attendanceService;
+    private final ChildService childService;
+
+    @Override
+    @PostMapping("/check-in")
+    public ResponseEntity<ApiResponse<Integer>> attendanceCheck(@AuthenticationPrincipal CustomUserDetails user) {
+        Child child = childService.getChild(user.getUsername());
+        int response = attendanceService.check(child); //연속 출석일 리턴
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    @Override
+    @GetMapping("/attendance-log")
+    public ResponseEntity<ApiResponse<List<AttendanceLogResponse>>> getAttendanceList() {
+        return null;
+    }
+}

--- a/domain/src/main/java/com/fintory/domain/attendence/dto/AttendanceCheckResponse.java
+++ b/domain/src/main/java/com/fintory/domain/attendence/dto/AttendanceCheckResponse.java
@@ -1,0 +1,7 @@
+package com.fintory.domain.attendence.dto;
+
+public record AttendanceCheckResponse(
+
+        Long continuousAttendance
+) {
+}

--- a/domain/src/main/java/com/fintory/domain/attendence/dto/AttendanceLogResponse.java
+++ b/domain/src/main/java/com/fintory/domain/attendence/dto/AttendanceLogResponse.java
@@ -1,0 +1,15 @@
+package com.fintory.domain.attendence.dto;
+
+import com.fintory.domain.attendence.model.AttendanceLog;
+
+import java.time.LocalDate;
+
+public record AttendanceLogResponse(
+        LocalDate attendanceLog
+) {
+    public static AttendanceLogResponse from(AttendanceLog log) {
+        return new AttendanceLogResponse(
+                log.getAttendanceDate()
+        );
+    }
+}

--- a/domain/src/main/java/com/fintory/domain/attendence/model/AttendanceLog.java
+++ b/domain/src/main/java/com/fintory/domain/attendence/model/AttendanceLog.java
@@ -11,19 +11,20 @@ import java.time.LocalDate;
 
 @Entity
 @Getter
-@Table(name="visit_log")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class VisitLog extends BaseEntity {
+@Table(name = "attendance_log", uniqueConstraints =
+@UniqueConstraint(name = "uk_child_attendance_date", columnNames = {"child_id", "attendance_date"}))
+public class AttendanceLog extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="child_id", nullable = false)
     private Child child;
 
-    @Column(name="visited_date", nullable = false)
-    private LocalDate visitedDate;
+    @Column(name="attendance_date", nullable = false)
+    private LocalDate attendanceDate;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private AttendanceStatus status;
-
+    public AttendanceLog(Child child, LocalDate attendanceDate) {
+        this.child = child;
+        this.attendanceDate = attendanceDate;
+    }
 }

--- a/domain/src/main/java/com/fintory/domain/attendence/model/AttendanceStatus.java
+++ b/domain/src/main/java/com/fintory/domain/attendence/model/AttendanceStatus.java
@@ -1,8 +1,0 @@
-package com.fintory.domain.attendence.model;
-
-public enum AttendanceStatus {
-
-    PRESENT,
-    ABSENT
-
-}

--- a/domain/src/main/java/com/fintory/domain/attendence/service/AttendanceService.java
+++ b/domain/src/main/java/com/fintory/domain/attendence/service/AttendanceService.java
@@ -1,0 +1,9 @@
+package com.fintory.domain.attendence.service;
+
+import com.fintory.domain.child.model.Child;
+
+public interface AttendanceService {
+
+
+    int check(Child child);
+}

--- a/domain/src/main/java/com/fintory/domain/attendence/service/AttendanceService.java
+++ b/domain/src/main/java/com/fintory/domain/attendence/service/AttendanceService.java
@@ -1,9 +1,14 @@
 package com.fintory.domain.attendence.service;
 
+import com.fintory.domain.attendence.dto.AttendanceLogResponse;
 import com.fintory.domain.child.model.Child;
+
+import java.util.List;
 
 public interface AttendanceService {
 
 
     int check(Child child);
+
+    List<AttendanceLogResponse> getAttendanceLogs(Child child);
 }

--- a/domain/src/main/java/com/fintory/domain/child/model/Child.java
+++ b/domain/src/main/java/com/fintory/domain/child/model/Child.java
@@ -2,7 +2,7 @@ package com.fintory.domain.child.model;
 
 import com.fintory.domain.account.model.Account;
 import com.fintory.domain.alarm.model.Alarm;
-import com.fintory.domain.attendence.model.VisitLog;
+import com.fintory.domain.attendence.model.AttendanceLog;
 import com.fintory.domain.challenge.model.Challenge;
 import com.fintory.domain.common.BaseEntity;
 import com.fintory.domain.common.Role;
@@ -97,6 +97,6 @@ public class Child extends BaseEntity {
     private List<Alarm> alarms;
 
     @OneToMany(cascade = CascadeType.ALL, mappedBy="child")
-    private List<VisitLog> visitLogs;
+    private List<AttendanceLog> visitLogs;
 
 }

--- a/domain/src/main/java/com/fintory/domain/child/service/ChildService.java
+++ b/domain/src/main/java/com/fintory/domain/child/service/ChildService.java
@@ -1,0 +1,8 @@
+package com.fintory.domain.child.service;
+
+import com.fintory.domain.child.model.Child;
+
+public interface ChildService {
+
+    Child getChild(String email);
+}

--- a/infra/build.gradle
+++ b/infra/build.gradle
@@ -56,6 +56,9 @@ dependencies {
     /* Jsoup */
     implementation 'org.jsoup:jsoup:1.17.2'
 
+    /* Test */
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
     /* swagger */
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8")
 

--- a/infra/src/main/java/com/fintory/infra/domain/attendance/repository/AttendanceRepository.java
+++ b/infra/src/main/java/com/fintory/infra/domain/attendance/repository/AttendanceRepository.java
@@ -6,10 +6,15 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Repository
 public interface AttendanceRepository extends JpaRepository<AttendanceLog, Long> {
 
 
     boolean existsByChildAndAttendanceDate(Child child, LocalDate today);
+
+    List<AttendanceLog> findAllByChild(Child child);
+
+    void deleteByAttendanceDateBefore(LocalDate cutoffDate);
 }

--- a/infra/src/main/java/com/fintory/infra/domain/attendance/repository/AttendanceRepository.java
+++ b/infra/src/main/java/com/fintory/infra/domain/attendance/repository/AttendanceRepository.java
@@ -1,0 +1,15 @@
+package com.fintory.infra.domain.attendance.repository;
+
+import com.fintory.domain.attendence.model.AttendanceLog;
+import com.fintory.domain.child.model.Child;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+
+@Repository
+public interface AttendanceRepository extends JpaRepository<AttendanceLog, Long> {
+
+
+    boolean existsByChildAndAttendanceDate(Child child, LocalDate today);
+}

--- a/infra/src/main/java/com/fintory/infra/domain/attendance/serviceImpl/AttendanceCleaner.java
+++ b/infra/src/main/java/com/fintory/infra/domain/attendance/serviceImpl/AttendanceCleaner.java
@@ -1,0 +1,24 @@
+package com.fintory.infra.domain.attendance.serviceImpl;
+
+import com.fintory.infra.domain.attendance.repository.AttendanceRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AttendanceCleaner {
+
+    private final AttendanceRepository attendanceRepository;
+
+    @Scheduled(cron = "0 0 0 1 * ?")
+    public void deleteLastMonthLogs() {
+        LocalDate cutoffDate = LocalDate.now().withDayOfMonth(1);
+        attendanceRepository.deleteByAttendanceDateBefore(cutoffDate);
+        log.info("{} 매월 1일 자정에 이전 달 로그 자동 삭제", cutoffDate);
+    }
+}

--- a/infra/src/main/java/com/fintory/infra/domain/attendance/serviceImpl/AttendanceServiceImpl.java
+++ b/infra/src/main/java/com/fintory/infra/domain/attendance/serviceImpl/AttendanceServiceImpl.java
@@ -1,0 +1,54 @@
+package com.fintory.infra.domain.attendance.serviceImpl;
+
+import com.fintory.domain.attendence.model.AttendanceLog;
+import com.fintory.domain.attendence.service.AttendanceService;
+import com.fintory.domain.child.model.Child;
+import com.fintory.infra.domain.attendance.repository.AttendanceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class AttendanceServiceImpl implements AttendanceService {
+
+    private final AttendanceRepository attendanceRepository;
+
+    @Override
+    public int check(Child child) {
+
+        LocalDate today = LocalDate.now();
+        // 출석 중복 여부
+        boolean isAlreadyChecked = attendanceRepository.existsByChildAndAttendanceDate(child, today);
+        if (!isAlreadyChecked) {
+            AttendanceLog attendanceLog = new AttendanceLog(child, today);
+            attendanceRepository.save(attendanceLog);
+        }
+        return calculateContinuousDays(child, today);
+    }
+
+    public int calculateContinuousDays(Child child, LocalDate today) {
+        // 오늘 출석은 이미 처리됨
+        int continuousDays = 0;
+        LocalDate checkDate = today.minusDays(1); // 어제부터 시작
+
+        // 어제가 이번 달이 아닐 경우 → 어차피 DB에 없음
+        if (checkDate.getMonth() != today.getMonth()) {
+            return 1; // 오늘만 출석한 것으로 간주
+        }
+
+        // 어제부터 거꾸로 연속 출석 체크
+        while (attendanceRepository.existsByChildAndAttendanceDate(child, checkDate)) {
+            continuousDays++;
+            checkDate = checkDate.minusDays(1);
+
+            // 이번 달 범위 안에서만 검사
+            if (checkDate.getMonth() != today.getMonth()) break;
+        }
+
+        return continuousDays + 1; // 오늘 출석 포함
+    }
+
+
+}

--- a/infra/src/main/java/com/fintory/infra/domain/attendance/serviceImpl/AttendanceServiceImpl.java
+++ b/infra/src/main/java/com/fintory/infra/domain/attendance/serviceImpl/AttendanceServiceImpl.java
@@ -1,5 +1,6 @@
 package com.fintory.infra.domain.attendance.serviceImpl;
 
+import com.fintory.domain.attendence.dto.AttendanceLogResponse;
 import com.fintory.domain.attendence.model.AttendanceLog;
 import com.fintory.domain.attendence.service.AttendanceService;
 import com.fintory.domain.child.model.Child;
@@ -8,6 +9,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -28,12 +31,22 @@ public class AttendanceServiceImpl implements AttendanceService {
         return calculateContinuousDays(child, today);
     }
 
+    @Override
+    public List<AttendanceLogResponse> getAttendanceLogs(Child child) {
+
+        List<AttendanceLog> logs = attendanceRepository.findAllByChild(child);
+
+        return logs.stream()
+                .map(AttendanceLogResponse::from)
+                .collect(Collectors.toList());
+    }
+
     public int calculateContinuousDays(Child child, LocalDate today) {
         // 오늘 출석은 이미 처리됨
         int continuousDays = 0;
         LocalDate checkDate = today.minusDays(1); // 어제부터 시작
 
-        // 어제가 이번 달이 아닐 경우 → 어차피 DB에 없음
+        // 어제가 이번 달이 아닐 경우(오늘이 1일일 경우) → 어차피 저번달은 DB에 없음
         if (checkDate.getMonth() != today.getMonth()) {
             return 1; // 오늘만 출석한 것으로 간주
         }

--- a/infra/src/main/java/com/fintory/infra/domain/child/serviceImpl/ChildServiceImpl.java
+++ b/infra/src/main/java/com/fintory/infra/domain/child/serviceImpl/ChildServiceImpl.java
@@ -1,0 +1,22 @@
+package com.fintory.infra.domain.child.serviceImpl;
+
+import com.fintory.common.exception.DomainErrorCode;
+import com.fintory.common.exception.DomainException;
+import com.fintory.domain.child.model.Child;
+import com.fintory.domain.child.service.ChildService;
+import com.fintory.infra.domain.child.repository.ChildRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChildServiceImpl implements ChildService {
+
+    private final ChildRepository childRepository;
+
+    @Override
+    public Child getChild(String email) {
+        return childRepository.findByEmail(email)
+                .orElseThrow(() -> new DomainException(DomainErrorCode.USER_NOT_FOUND));
+    }
+}

--- a/infra/src/main/java/com/fintory/infra/swagger/SwaggerConfig.java
+++ b/infra/src/main/java/com/fintory/infra/swagger/SwaggerConfig.java
@@ -5,16 +5,26 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SwaggerConfig {
 
+    @Value("${spring.profiles.active}")
+    private String activeProfile;
+
     @Bean
     public OpenAPI customOpenAPI() {
-        return new OpenAPI()
-                .addServersItem(new Server().url("https://fintory.xyz"))
+
+        OpenAPI openAPI = new OpenAPI();
+
+        if (activeProfile.equals("deploy")) {
+            openAPI.addServersItem(new Server().url("https://fintory.xyz"));
+        }
+
+        return openAPI
                 .addSecurityItem(new SecurityRequirement().addList("Authorization")) // 기본값: 모든 api 보안 필요
                 .components(new Components()
                         .addSecuritySchemes("Authorization",

--- a/infra/src/test/java/com/fintory/infra/domain/attendance/serviceImpl/AttendanceServiceImplTest.java
+++ b/infra/src/test/java/com/fintory/infra/domain/attendance/serviceImpl/AttendanceServiceImplTest.java
@@ -1,0 +1,90 @@
+package com.fintory.infra.domain.attendance.serviceImpl;
+
+import com.fintory.domain.child.model.Child;
+import com.fintory.infra.domain.attendance.repository.AttendanceRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class) // 모키토 객체 활성화
+class AttendanceServiceImplTest {
+
+    @InjectMocks // 테스트 대상 실제 클래스
+    private AttendanceServiceImpl attendanceService;
+
+    @Mock // 가짜 db 객체
+    private AttendanceRepository attendanceRepository;
+
+    // 테스트용 더미 유저
+    private Child child;
+
+    @BeforeEach
+    void setUp() {
+        child = mock(Child.class);
+    }
+
+    @Test
+    void 연속_출석_2일이면_3리턴() {
+        // given
+        LocalDate today = LocalDate.of(2025, 9, 6);
+
+        when(attendanceRepository.existsByChildAndAttendanceDate(child, today.minusDays(1))).thenReturn(true);  // 9/5
+        when(attendanceRepository.existsByChildAndAttendanceDate(child, today.minusDays(2))).thenReturn(true);  // 9/4
+        when(attendanceRepository.existsByChildAndAttendanceDate(child, today.minusDays(3))).thenReturn(false);  // 9/3
+        // when
+        int result = attendanceService.calculateContinuousDays(child, today);
+
+        // then
+        assertEquals(3, result); // 3일 + 오늘
+    }
+
+    @Test
+    void 어제가_지난달이면_1리턴() {
+        // given
+        LocalDate today = LocalDate.of(2025, 9, 1); // 어제 = 8/31 (지난달)
+
+        // when
+        int result = attendanceService.calculateContinuousDays(child, today);
+
+        // then
+        assertEquals(1, result);
+    }
+
+    @Test
+    void 어제_출석없으면_1리턴() {
+        // given
+        LocalDate today = LocalDate.of(2025, 9, 3);
+
+        when(attendanceRepository.existsByChildAndAttendanceDate(child, today.minusDays(1))).thenReturn(false);  // 9/2
+
+        // when
+        int result = attendanceService.calculateContinuousDays(child, today);
+
+        // then
+        assertEquals(1, result); // 오늘만 출석
+    }
+
+    @Test
+    void 이틀만_연속출석하면_3리턴() {
+        // given
+        LocalDate today = LocalDate.of(2025, 9, 3);
+
+        when(attendanceRepository.existsByChildAndAttendanceDate(child, today.minusDays(1))).thenReturn(true);  // 9/2
+        when(attendanceRepository.existsByChildAndAttendanceDate(child, today.minusDays(2))).thenReturn(true);  // 9/1
+
+        // when
+        int result = attendanceService.calculateContinuousDays(child, today);
+
+        // then
+        assertEquals(3, result);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #34 

## 📝작업 내용

- 출석 체크 기능: 하루에 한번만 앱 접속시 자동 출석
- 연속출석일 반환 기능 구현
- 연속출석 계산 메소드 테스트 코드
- 출석 리스트 모두 불러오기 기능 구현
- 매월 1일 자정에 이전 달 출석 기록 자동 삭제 스케줄러 구현

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- 머지전에 이전 pr에서 합쳐야하는 부분이 있어서 rebase후 다시 pr올렸습니다 커밋은 출석체크부분만 보시면 됩니다
