### PR TITLE
feat : 하루치 기간별 시세에서 한시간 단위 기간별 시세로 변경 (분단위 저장)

### DIFF
--- a/auth/src/main/java/com/fintory/auth/util/OpenApiList.java
+++ b/auth/src/main/java/com/fintory/auth/util/OpenApiList.java
@@ -50,6 +50,7 @@ public class OpenApiList {
             "/api/child/stock/**",
             "/stock/**",
             "/ws/**",
+            "/ws-sockjs/**"
 
     };
 }

--- a/domain/src/main/java/com/fintory/domain/stock/model/IntervalType.java
+++ b/domain/src/main/java/com/fintory/domain/stock/model/IntervalType.java
@@ -1,5 +1,5 @@
 package com.fintory.domain.stock.model;
 
 public enum IntervalType {
-    DAILY,WEEKLY,QUARTERLY, YEARLY, FIVE_YEARLY, TOTAL
+    HOURLY,WEEKLY,QUARTERLY, YEARLY, FIVE_YEARLY, TOTAL
 }

--- a/domain/src/main/java/com/fintory/domain/stock/model/StockPriceHistory.java
+++ b/domain/src/main/java/com/fintory/domain/stock/model/StockPriceHistory.java
@@ -38,12 +38,8 @@ public class StockPriceHistory extends BaseEntity {
     @JoinColumn(name="stock_id")
     private Stock stock;
 
-    public StockPriceHistory updateStockPriceHistory(BigDecimal openPrice, BigDecimal closePrice, BigDecimal highPrice, BigDecimal lowPrice) {
-        this.openPrice = openPrice;
+    public StockPriceHistory updateStockPriceHistory(BigDecimal closePrice) {
         this.closePrice = closePrice;
-        this.highPrice = highPrice;
-        this.lowPrice = lowPrice;
-
         return this;
     }
 

--- a/infra/src/main/java/com/fintory/infra/domain/stock/repository/StockPriceHistoryRepository.java
+++ b/infra/src/main/java/com/fintory/infra/domain/stock/repository/StockPriceHistoryRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -21,4 +22,12 @@ public interface StockPriceHistoryRepository extends JpaRepository<StockPriceHis
     @Query("SELECT sph.closePrice FROM StockPriceHistory sph WHERE sph.stock =:stock ORDER BY sph.date DESC LIMIT 1 ")
     BigDecimal findByStockAndDate(Stock stock);
 
+    @Query("SELECT sph FROM StockPriceHistory sph WHERE sph.stock=:stock AND sph.intervalType=:intervalType AND sph.date=:now ORDER BY sph.updatedAt ASC LIMIT 1")
+    Optional<StockPriceHistory> findOldestByStockAndIntervalTypeAndDate(Stock stock, IntervalType intervalType, LocalDate now);
+
+    List<StockPriceHistory> findByStockAndIntervalTypeOrderByDateAsc(Stock stock, IntervalType intervalType);
+
+    void deleteByStockAndIntervalTypeAndDateBefore(Stock stock, IntervalType intervalType, LocalDate now);
+
+    List<StockPriceHistory> findByStockAndIntervalTypeOrderByUpdatedAtAsc(Stock stock, IntervalType intervalType);
 }

--- a/infra/src/main/java/com/fintory/infra/domain/stock/service/korean/KoreanStockPriceHistoryServiceImpl.java
+++ b/infra/src/main/java/com/fintory/infra/domain/stock/service/korean/KoreanStockPriceHistoryServiceImpl.java
@@ -102,7 +102,7 @@ public class KoreanStockPriceHistoryServiceImpl implements KoreanStockPriceHisto
         Map<String, List<KoreanStockPriceHistory>> chartData = new HashMap<>();
         Stock stock = stockRepository.findByCode(code).orElseThrow(() -> new DomainException(DomainErrorCode.STOCK_NOT_FOUND));
 
-        chartData.put("1D", getKoreanStockPriceHistoryByInterval(stock, IntervalType.DAILY));
+        chartData.put("1D", getKoreanStockPriceHistoryByInterval(stock, IntervalType.HOURLY));
         chartData.put("1W", getFilteredData(stock, IntervalType.QUARTERLY,LocalDate.now().minusWeeks(1)));
         chartData.put("3M", getFilteredData(stock, IntervalType.QUARTERLY, LocalDate.now().minusMonths(3)));
         chartData.put("1Y", getKoreanStockPriceHistoryByInterval(stock, IntervalType.YEARLY));
@@ -126,25 +126,16 @@ public class KoreanStockPriceHistoryServiceImpl implements KoreanStockPriceHisto
 
     //DB에서 기간별 시세 조회
     private List<KoreanStockPriceHistory> getKoreanStockPriceHistoryByInterval(Stock stock, IntervalType intervalType) {
-        List<StockPriceHistory> stockPriceHistories = stockPriceHistoryRepository.findByStockAndIntervalType(stock, intervalType);
+        List<StockPriceHistory> stockPriceHistories;
 
-        //오늘날짜가 아닌 DAILY 기간별 시세가 저장되어 있는 경우 ->
-
-        List<StockPriceHistory> toDelete = stockPriceHistories.stream()
-                .filter(history->history.getDate().equals(LocalDate.now()))
-                .toList();
-
-        stockPriceHistoryRepository.deleteAll(toDelete);
-
-        if(intervalType == IntervalType.DAILY) {
-            return stockPriceHistories.stream()
-                    .sorted(Comparator.comparing(StockPriceHistory::getUpdatedAt))
-                    .map(this::convertToKoreanStockPriceHistory)
-                    .toList();
+        if(intervalType == IntervalType.HOURLY) {
+            //기간별 시세 데이터를 updateAt 기준으로 정렬해서 조회
+            stockPriceHistories =  stockPriceHistoryRepository.findByStockAndIntervalTypeOrderByUpdatedAtAsc(stock, intervalType);
+        }else{
+            stockPriceHistories = stockPriceHistoryRepository.findByStockAndIntervalTypeOrderByDateAsc(stock, intervalType);
         }
 
         return stockPriceHistories.stream()
-                .sorted(Comparator.comparing(StockPriceHistory::getDate)) // 날짜순 정렬
                 .map(this::convertToKoreanStockPriceHistory)
                 .toList();
     }

--- a/infra/src/main/java/com/fintory/infra/domain/stock/service/overseas/OverseasStockPriceHistoryServiceImpl.java
+++ b/infra/src/main/java/com/fintory/infra/domain/stock/service/overseas/OverseasStockPriceHistoryServiceImpl.java
@@ -101,7 +101,7 @@ public class OverseasStockPriceHistoryServiceImpl implements OverseasStockPriceH
         Map<String, List<OverseasStockPriceHistory>> chartData = new HashMap<>();
         Stock stock = stockRepository.findByCode(code).orElseThrow(() -> new DomainException(DomainErrorCode.STOCK_NOT_FOUND));
 
-        chartData.put("1D", getOverseasStockPriceHistoryByInterval(stock, IntervalType.DAILY ));
+        chartData.put("1D", getOverseasStockPriceHistoryByInterval(stock, IntervalType.HOURLY));
         chartData.put("1W", getFilteredData(stock, IntervalType.QUARTERLY,LocalDate.now().minusWeeks(1)));
         chartData.put("3M", getFilteredData(stock, IntervalType.QUARTERLY, LocalDate.now().minusMonths(3)));
         chartData.put("1Y", getOverseasStockPriceHistoryByInterval(stock, IntervalType.YEARLY));
@@ -125,19 +125,20 @@ public class OverseasStockPriceHistoryServiceImpl implements OverseasStockPriceH
 
     //DB에서 기간별 시세 조회
     private List<OverseasStockPriceHistory> getOverseasStockPriceHistoryByInterval(Stock stock, IntervalType intervalType) {
-        List<StockPriceHistory> stockPriceHistories = stockPriceHistoryRepository.findByStockAndIntervalType(stock, intervalType);
+        List<StockPriceHistory> stockPriceHistories; //DB에서 정렬해서 가져오기
 
-        if(intervalType == IntervalType.DAILY) {
-            return stockPriceHistories.stream()
-                    .sorted(Comparator.comparing(StockPriceHistory::getUpdatedAt))
-                    .map(this::convertToOverseasStockPriceHistory)
-                    .toList();
+        if(intervalType == IntervalType.HOURLY) {
+            //가장 최신의 date의 (공휴일, 주말 고려) 기간별 시세 데이터를 updateAt 기준으로 정렬해서 조회
+            stockPriceHistories = stockPriceHistoryRepository.findByStockAndIntervalTypeOrderByUpdatedAtAsc(stock,intervalType);
+
+        }else {
+            stockPriceHistories = stockPriceHistoryRepository.findByStockAndIntervalTypeOrderByDateAsc(stock, intervalType);
         }
 
         return stockPriceHistories.stream()
-                .sorted(Comparator.comparing(StockPriceHistory::getDate)) // 날짜순 정렬
                 .map(this::convertToOverseasStockPriceHistory)
                 .toList();
+
     }
 
     private OverseasStockPriceHistory convertToOverseasStockPriceHistory(StockPriceHistory priceHistory) {

--- a/infra/src/main/java/com/fintory/infra/domain/stock/service/websocket/LiveStockPriceWebsocketServiceImpl.java
+++ b/infra/src/main/java/com/fintory/infra/domain/stock/service/websocket/LiveStockPriceWebsocketServiceImpl.java
@@ -75,6 +75,9 @@ public class LiveStockPriceWebsocketServiceImpl implements LiveStockPriceWebsock
     private volatile AtomicBoolean  isOverseasConnected = new AtomicBoolean(false);
     private String cachedAccessToken;
 
+    private static LocalDate lastCleanupDate = null;
+
+
 
     public LiveStockPriceWebsocketServiceImpl(
             @Qualifier("koreanLiveStockPriceWebSocketConnectionManager") WebSocketConnectionManager koreanConnectionManager,
@@ -273,7 +276,7 @@ public class LiveStockPriceWebsocketServiceImpl implements LiveStockPriceWebsock
 
     /* 스케줄링 - 배치 저장 */
     //REVIEW 지금은 1시간 간격 -> 1분은 너무 많음.
-    @Scheduled(cron = "0 0  9-15 * * MON-FRI", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 * 9-15 * * MON-FRI", zone = "Asia/Seoul")
     public void saveKoreanStockDataBatch() {
         if (!isKoreanMarketOpen()) {
             log.debug("국내 장 마감으로 인한 배치 저장 중단");
@@ -282,7 +285,7 @@ public class LiveStockPriceWebsocketServiceImpl implements LiveStockPriceWebsock
         saveBatchData("국내", koreanPendingData);
     }
 
-    @Scheduled(cron = "0 0 9-15 * * MON-FRI", zone = "America/New_York")
+    @Scheduled(cron = "0 * 9-15 * * MON-FRI", zone = "America/New_York")
     public void saveOverseasStockDataBatch() {
         if (!isOverseasMarketOpen()) {
             log.debug("해외 장 마감으로 인한 배치 저장 중단");
@@ -320,12 +323,27 @@ public class LiveStockPriceWebsocketServiceImpl implements LiveStockPriceWebsock
         liveStockPrice.updateLiveStockPrice(dto.currentPrice(), dto.priceChange(), dto.priceChangeRate());
         liveStockPriceRepository.save(liveStockPrice);
 
-        StockPriceHistory stockPriceHistory = StockPriceHistory.builder()
-                .closePrice(dto.currentPrice())
-                .stock(stock)
-                .intervalType(IntervalType.DAILY)
-                .date(LocalDate.now())
-                .build();
+
+        //오늘 날짜
+        LocalDate now = LocalDate.now();
+
+        // 오늘이 아닌 이전 날짜의 HOURLY 데이터 모두 삭제
+        // 매번 웹소켓 데이터 저장 시 삭제 쿼리 실행 방지
+        if(!now.equals(lastCleanupDate)) {
+            stockPriceHistoryRepository.deleteByStockAndIntervalTypeAndDateBefore(stock, IntervalType.HOURLY, now);
+            lastCleanupDate = now;
+        }
+
+        //오늘날짜 HOURLY 데이터 중에서 updateAt이 가장 오래된 것을 찾아서 closePrice를 새로운 가격으로 업데이트
+        StockPriceHistory stockPriceHistory = stockPriceHistoryRepository.findOldestByStockAndIntervalTypeAndDate(stock,IntervalType.HOURLY,now)
+                .orElseGet(()->StockPriceHistory.builder()
+                        .closePrice(dto.currentPrice())
+                        .stock(stock)
+                        .intervalType(IntervalType.HOURLY)
+                        .date(now)
+                        .build());
+
+        stockPriceHistory =stockPriceHistory.updateStockPriceHistory(dto.currentPrice());
 
         stockPriceHistoryRepository.save(stockPriceHistory);
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #62 

## 📝작업 내용

> 하루치 기간별 시세에서 한시간 단위 기간별 시세로 변경

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
- 종목별로 hourly는 60개의 데이터만 존재. (웹소켓을 통해 값을 받으면 이전 hourly 데이터는 지워짐.) 
- updateAt을 기준으로 정렬된 hourly 데이터를 프론트에게 응답함

