### PR TITLE
[FEAT] 감시가 기능 구현

### DIFF
--- a/app-child/src/main/java/com/fintory/child/domain/alarm/controller/PriceAlertController.java
+++ b/app-child/src/main/java/com/fintory/child/domain/alarm/controller/PriceAlertController.java
@@ -1,0 +1,39 @@
+package com.fintory.child.domain.alarm.controller;
+
+import com.fintory.auth.util.CustomUserDetails;
+import com.fintory.common.api.ApiResponse;
+import com.fintory.domain.alarm.dto.PriceAlertRequest;
+import com.fintory.domain.alarm.dto.PriceAlertResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
+
+@Tag(name = "감시가 지정 API")
+public interface PriceAlertController {
+
+    @Operation(summary = "감시가 생성")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "감시가 생성 성공")
+    ResponseEntity<ApiResponse<Void>> createPriceAlert(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @RequestBody PriceAlertRequest request
+    );
+
+    @Operation(summary = "감시가 목록 조회")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "감시가 목록 반환")
+    ResponseEntity<ApiResponse<List<PriceAlertResponse>>> getPriceAlerts(
+            @PathVariable String stockCode,
+            @AuthenticationPrincipal CustomUserDetails user
+    );
+
+    @Operation(summary = "감시가 삭제")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "감시가 삭제 성공")
+    ResponseEntity<ApiResponse<Void>> deletePriceAlert(
+            @PathVariable Long id,
+            @AuthenticationPrincipal CustomUserDetails user
+    );
+}

--- a/app-child/src/main/java/com/fintory/child/domain/alarm/controller/PriceAlertControllerImpl.java
+++ b/app-child/src/main/java/com/fintory/child/domain/alarm/controller/PriceAlertControllerImpl.java
@@ -1,0 +1,53 @@
+package com.fintory.child.domain.alarm.controller;
+
+import com.fintory.auth.util.CustomUserDetails;
+import com.fintory.common.api.ApiResponse;
+import com.fintory.domain.alarm.dto.PriceAlertRequest;
+import com.fintory.domain.alarm.dto.PriceAlertResponse;
+import com.fintory.domain.alarm.service.PriceAlertService;
+import com.fintory.domain.child.model.Child;
+import com.fintory.domain.child.service.ChildService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/child/price-alerts")
+@RequiredArgsConstructor
+public class PriceAlertControllerImpl implements PriceAlertController{
+
+    private final PriceAlertService priceAlertService;
+    private final ChildService childService;
+
+    @Override
+    @PostMapping
+    public ResponseEntity<ApiResponse<Void>> createPriceAlert(@AuthenticationPrincipal CustomUserDetails user, @RequestBody PriceAlertRequest request){
+        Child child = childService.getChild(user.getUsername());
+        priceAlertService.createPriceAlert(child,request);
+        return ResponseEntity.ok(ApiResponse.ok(null));
+
+    }
+
+    @Override
+    @GetMapping("/{stockCode}")
+    public ResponseEntity<ApiResponse<List<PriceAlertResponse>>> getPriceAlerts(
+            @PathVariable String stockCode,
+            @AuthenticationPrincipal CustomUserDetails user){
+        Child child = childService.getChild(user.getUsername());
+        List<PriceAlertResponse> priceAlertResponses = priceAlertService.getPriceAlerts(child,stockCode);
+        return ResponseEntity.ok(ApiResponse.ok(priceAlertResponses));
+    }
+
+
+    @Override
+    @DeleteMapping("/{priceAlertId}")
+    public ResponseEntity<ApiResponse<Void>> deletePriceAlert(@PathVariable Long priceAlertId, @AuthenticationPrincipal CustomUserDetails user){
+        Child child = childService.getChild(user.getUsername());
+        priceAlertService.deletePriceAlert(priceAlertId,child);
+        return ResponseEntity.ok(ApiResponse.ok(null));
+    }
+
+}

--- a/app-child/src/main/java/com/fintory/child/domain/trading/controller/TradingControllerImpl.java
+++ b/app-child/src/main/java/com/fintory/child/domain/trading/controller/TradingControllerImpl.java
@@ -3,7 +3,7 @@ package com.fintory.child.domain.trading.controller;
 import com.fintory.auth.util.CustomUserDetails;
 import com.fintory.common.api.ApiResponse;
 import com.fintory.domain.portfolio.dto.TradeRequest;
-import com.fintory.domain.stock.service.TradingService;
+import com.fintory.domain.portfolio.service.TradingService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;

--- a/common/src/main/java/com/fintory/common/exception/DomainErrorCode.java
+++ b/common/src/main/java/com/fintory/common/exception/DomainErrorCode.java
@@ -72,6 +72,10 @@ public enum DomainErrorCode {
     //live stock price
     LIVE_STOCK_PRICE_NOT_FOUND(HttpStatus.NOT_FOUND,"LIVE_STOCK_PRICE_NOT_FOUND","현재가 데이터를 찾을 수 없습니다."),
 
+    // price alert
+    PRICE_ALERT_NOT_FOUND(HttpStatus.NOT_FOUND,"PRICE_ALERT_NOT_FOUND","해당 감시가 데이터를 찾을 수 없습니다"),
+    PRICE_ALERT_FORBIDDEN(HttpStatus.FORBIDDEN,"PRICE_ALERT_FORBIDDEN","해당 감시가 데이터에 대한 권한이 없습니다."),
+
     //report
     REPORT_NOT_FOUND(HttpStatus.NOT_FOUND,"REPORT_NOT_FOUND","리포트를 찾을 수 없습니다."),
 

--- a/domain/src/main/java/com/fintory/domain/alarm/dto/PriceAlertRequest.java
+++ b/domain/src/main/java/com/fintory/domain/alarm/dto/PriceAlertRequest.java
@@ -1,0 +1,9 @@
+package com.fintory.domain.alarm.dto;
+
+import java.math.BigDecimal;
+
+public record PriceAlertRequest(
+         String stockCode,
+         BigDecimal targetPrice
+){
+}

--- a/domain/src/main/java/com/fintory/domain/alarm/dto/PriceAlertResponse.java
+++ b/domain/src/main/java/com/fintory/domain/alarm/dto/PriceAlertResponse.java
@@ -1,0 +1,9 @@
+package com.fintory.domain.alarm.dto;
+
+import java.math.BigDecimal;
+
+public record PriceAlertResponse(
+        Long id,
+        BigDecimal targetPrice
+) {
+}

--- a/domain/src/main/java/com/fintory/domain/alarm/model/PriceAlert.java
+++ b/domain/src/main/java/com/fintory/domain/alarm/model/PriceAlert.java
@@ -1,7 +1,8 @@
-package com.fintory.domain.stock.model;
+package com.fintory.domain.alarm.model;
 
 import com.fintory.domain.child.model.Child;
 import com.fintory.domain.common.BaseEntity;
+import com.fintory.domain.stock.model.Stock;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/domain/src/main/java/com/fintory/domain/alarm/model/PriceAlert.java
+++ b/domain/src/main/java/com/fintory/domain/alarm/model/PriceAlert.java
@@ -16,7 +16,7 @@ import java.math.BigDecimal;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PriceAlert extends BaseEntity {
 
-    @Column(name="target_price")
+    @Column(name="target_price",precision = 15, scale=3)
     private BigDecimal targetPrice;
 
     @ManyToOne

--- a/domain/src/main/java/com/fintory/domain/alarm/service/PriceAlertService.java
+++ b/domain/src/main/java/com/fintory/domain/alarm/service/PriceAlertService.java
@@ -1,0 +1,18 @@
+package com.fintory.domain.alarm.service;
+
+import com.fintory.domain.alarm.dto.PriceAlertRequest;
+import com.fintory.domain.alarm.dto.PriceAlertResponse;
+import com.fintory.domain.child.model.Child;
+
+import java.util.List;
+
+public interface PriceAlertService {
+
+    void createPriceAlert(Child child,PriceAlertRequest priceAlertRequest);
+
+    List<PriceAlertResponse> getPriceAlerts(Child child,String stockCode);
+
+    void deletePriceAlert(Long priceAlertId, Child child);
+
+
+}

--- a/domain/src/main/java/com/fintory/domain/child/model/Child.java
+++ b/domain/src/main/java/com/fintory/domain/child/model/Child.java
@@ -9,7 +9,7 @@ import com.fintory.domain.common.Role;
 import com.fintory.domain.common.User;
 import com.fintory.domain.consulting.model.Report;
 import com.fintory.domain.point.model.PointWallet;
-import com.fintory.domain.stock.model.PriceAlert;
+import com.fintory.domain.alarm.model.PriceAlert;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/domain/src/main/java/com/fintory/domain/child/model/Child.java
+++ b/domain/src/main/java/com/fintory/domain/child/model/Child.java
@@ -9,6 +9,7 @@ import com.fintory.domain.common.Role;
 import com.fintory.domain.common.User;
 import com.fintory.domain.consulting.model.Report;
 import com.fintory.domain.point.model.PointWallet;
+import com.fintory.domain.stock.model.PriceAlert;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -90,6 +91,7 @@ public class Child extends BaseEntity implements User {
     @OneToMany(cascade = CascadeType.ALL, mappedBy = "child")
     private List<Report> reports;
 
-
+    @OneToMany(cascade = CascadeType.ALL, mappedBy = "child")
+    private List<PriceAlert> priceAlerts;
 
 }

--- a/domain/src/main/java/com/fintory/domain/portfolio/service/ExchangeRateService.java
+++ b/domain/src/main/java/com/fintory/domain/portfolio/service/ExchangeRateService.java
@@ -1,4 +1,4 @@
-package com.fintory.domain.stock.service;
+package com.fintory.domain.portfolio.service;
 
 import java.math.BigDecimal;
 

--- a/domain/src/main/java/com/fintory/domain/portfolio/service/TradingService.java
+++ b/domain/src/main/java/com/fintory/domain/portfolio/service/TradingService.java
@@ -1,11 +1,6 @@
-package com.fintory.domain.stock.service;
+package com.fintory.domain.portfolio.service;
 
-import com.fintory.domain.account.model.Account;
 import com.fintory.domain.portfolio.dto.TradeRequest;
-import com.fintory.domain.portfolio.model.TransactionType;
-import com.fintory.domain.stock.model.Stock;
-
-import java.math.BigDecimal;
 
 public interface TradingService {
 

--- a/domain/src/main/java/com/fintory/domain/stock/model/PriceAlert.java
+++ b/domain/src/main/java/com/fintory/domain/stock/model/PriceAlert.java
@@ -1,0 +1,32 @@
+package com.fintory.domain.stock.model;
+
+import com.fintory.domain.child.model.Child;
+import com.fintory.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Entity
+@Getter
+@Table(name="price_alert")
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PriceAlert extends BaseEntity {
+
+    @Column(name="target_price")
+    private BigDecimal targetPrice;
+
+    @ManyToOne
+    @JoinColumn(name="child_id")
+    private Child child;
+
+    @ManyToOne
+    @JoinColumn(name="stock_id")
+    private Stock stock;
+
+
+    //REVIEW 감시가는 단순히 특정 가격이 되면 알림 보내기 용도 -> 굳이 삭제된 데이터를 보관할 이유가 없음
+    // 과거 감시가 데이터가 의미없는 상황에서 소프트 딜리트는 쓸모없는 데이터가 계속 쌓이는 것으로 판단. 혹시 필요하다면 소프트 딜리트 추가하겠음
+}

--- a/domain/src/main/java/com/fintory/domain/stock/model/Stock.java
+++ b/domain/src/main/java/com/fintory/domain/stock/model/Stock.java
@@ -46,4 +46,7 @@ public class Stock extends BaseEntity {
 
     @OneToMany(cascade=CascadeType.ALL, mappedBy="stock")
     private List<OwnedStock> ownedStocks;
+
+    @OneToMany(cascade = CascadeType.ALL,mappedBy = "stock")
+    private List<PriceAlert> priceAlerts;
 }

--- a/domain/src/main/java/com/fintory/domain/stock/model/Stock.java
+++ b/domain/src/main/java/com/fintory/domain/stock/model/Stock.java
@@ -1,5 +1,6 @@
 package com.fintory.domain.stock.model;
 
+import com.fintory.domain.alarm.model.PriceAlert;
 import com.fintory.domain.common.BaseEntity;
 import com.fintory.domain.portfolio.model.OwnedStock;
 import com.fintory.domain.portfolio.model.StockTransaction;

--- a/infra/src/main/java/com/fintory/infra/domain/alarm/repository/PriceAlertRepository.java
+++ b/infra/src/main/java/com/fintory/infra/domain/alarm/repository/PriceAlertRepository.java
@@ -1,0 +1,11 @@
+package com.fintory.infra.domain.alarm.repository;
+
+import com.fintory.domain.alarm.model.PriceAlert;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PriceAlertRepository extends JpaRepository<PriceAlert,Long> {
+
+    List<PriceAlert> findByChildIdAndStockCode(Long id, String stockCode);
+}

--- a/infra/src/main/java/com/fintory/infra/domain/alarm/serviceImpl/PriceAlertServiceImpl.java
+++ b/infra/src/main/java/com/fintory/infra/domain/alarm/serviceImpl/PriceAlertServiceImpl.java
@@ -1,0 +1,60 @@
+package com.fintory.infra.domain.alarm.serviceImpl;
+
+import com.fintory.common.exception.DomainErrorCode;
+import com.fintory.common.exception.DomainException;
+import com.fintory.domain.alarm.dto.PriceAlertRequest;
+import com.fintory.domain.alarm.dto.PriceAlertResponse;
+import com.fintory.domain.alarm.model.PriceAlert;
+import com.fintory.domain.alarm.service.PriceAlertService;
+import com.fintory.domain.child.model.Child;
+import com.fintory.domain.stock.model.Stock;
+import com.fintory.infra.domain.alarm.repository.PriceAlertRepository;
+import com.fintory.infra.domain.stock.repository.StockRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PriceAlertServiceImpl implements PriceAlertService {
+
+    private final PriceAlertRepository priceAlertRepository;
+    private final StockRepository stockRepository;
+
+    @Transactional
+    @Override
+    public void createPriceAlert(Child child,PriceAlertRequest priceAlertRequest) {
+        Stock stock = stockRepository.findByCode(priceAlertRequest.stockCode()).orElseThrow(()->new DomainException(DomainErrorCode.STOCK_NOT_FOUND));
+        PriceAlert priceAlert = PriceAlert.builder()
+                .targetPrice(priceAlertRequest.targetPrice())
+                .child(child)
+                .stock(stock)
+                .build();
+
+        priceAlertRepository.save(priceAlert);
+    }
+
+    @Override
+    public List<PriceAlertResponse> getPriceAlerts(Child child,String stockCode) {
+        List<PriceAlert> priceAlertList = priceAlertRepository.findByChildIdAndStockCode(child.getId(), stockCode);
+
+        return priceAlertList.stream()
+                .map(priceAlert ->new PriceAlertResponse(priceAlert.getId(),priceAlert.getTargetPrice()))
+                .toList();
+    }
+
+    @Transactional
+    @Override
+    public void deletePriceAlert(Long priceAlertId,Child child) {
+        PriceAlert priceAlert = priceAlertRepository.findById(priceAlertId).orElseThrow(()-> new DomainException(DomainErrorCode.PRICE_ALERT_NOT_FOUND));
+        if(!priceAlert.getChild().equals(child)) {
+            throw new DomainException(DomainErrorCode.PRICE_ALERT_FORBIDDEN);
+        }
+        priceAlertRepository.delete(priceAlert);
+    }
+}

--- a/infra/src/main/java/com/fintory/infra/domain/consulting/serviceImpl/ConsultingServiceImpl.java
+++ b/infra/src/main/java/com/fintory/infra/domain/consulting/serviceImpl/ConsultingServiceImpl.java
@@ -12,7 +12,7 @@ import com.fintory.domain.portfolio.model.OwnedStock;
 import com.fintory.domain.portfolio.model.StockTransaction;
 import com.fintory.domain.portfolio.model.TransactionType;
 import com.fintory.domain.stock.model.LiveStockPrice;
-import com.fintory.domain.stock.service.ExchangeRateService;
+import com.fintory.domain.portfolio.service.ExchangeRateService;
 import com.fintory.infra.domain.consulting.repository.ReportRepository;
 import com.fintory.infra.domain.portfolio.repository.OwnedStockRepository;
 import com.fintory.infra.domain.stock.repository.LiveStockPriceRepository;

--- a/infra/src/main/java/com/fintory/infra/domain/portfolio/serviceImpl/ExchangeRateServiceImpl.java
+++ b/infra/src/main/java/com/fintory/infra/domain/portfolio/serviceImpl/ExchangeRateServiceImpl.java
@@ -1,8 +1,8 @@
-package com.fintory.infra.domain.trading;
+package com.fintory.infra.domain.portfolio.serviceImpl;
 
 import com.fintory.common.exception.DomainErrorCode;
 import com.fintory.common.exception.DomainException;
-import com.fintory.domain.stock.service.ExchangeRateService;
+import com.fintory.domain.portfolio.service.ExchangeRateService;
 import com.fintory.infra.domain.portfolio.properties.EosProperties;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/infra/src/main/java/com/fintory/infra/domain/portfolio/serviceImpl/TradingServiceImpl.java
+++ b/infra/src/main/java/com/fintory/infra/domain/portfolio/serviceImpl/TradingServiceImpl.java
@@ -1,4 +1,4 @@
-package com.fintory.infra.domain.trading;
+package com.fintory.infra.domain.portfolio.serviceImpl;
 
 
 import com.fintory.common.exception.DomainErrorCode;
@@ -11,8 +11,8 @@ import com.fintory.domain.portfolio.dto.TradeCalculation;
 import com.fintory.domain.portfolio.dto.TradeRequest;
 import com.fintory.domain.portfolio.model.*;
 import com.fintory.domain.stock.model.Stock;
-import com.fintory.domain.stock.service.ExchangeRateService;
-import com.fintory.domain.stock.service.TradingService;
+import com.fintory.domain.portfolio.service.ExchangeRateService;
+import com.fintory.domain.portfolio.service.TradingService;
 import com.fintory.infra.domain.account.repository.AccountRepository;
 import com.fintory.infra.domain.child.repository.ChildRepository;
 import com.fintory.infra.domain.portfolio.repository.OwnedStockRepository;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #51 

## 📝작업 내용

> 감시가 생성, 삭제, 조회 기능 구현

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 감시가 생성, 삭제, 조회 기능만 구현된 상태.
> 패키지 위치가 현재 alarm에 있는데, 바꿔야 한다면 리뷰 주세용  
> 그리고 피그마에서 보니까 -> 특정 주식창에서 감시가를 보는 구조인것 같더라구요? (현재가와 같이 감시가를 볼 수 있음) 그래서 지금은 특정 주식창에서 설정한 감시가를 보는 기능만 구현되어 있는데 혹시 전체 감시가 보기 기능이 필요하면 추가하겠습니다.