### PR TITLE
[REFACTOR] 포인트, 계좌 도메인에서 생성자 및 setter 방식 통일

### DIFF
--- a/domain/src/main/java/com/fintory/domain/account/model/Account.java
+++ b/domain/src/main/java/com/fintory/domain/account/model/Account.java
@@ -46,25 +46,15 @@ public class Account extends BaseEntity {
     @OneToMany(cascade=CascadeType.ALL,mappedBy="account")
     private List<Report> reports;
 
-    // 생성 + 도메인 -> 생성자 대신 정적 팩토리 메소드
-    public static Account createWithInitialDeposit(Child child, BigDecimal initialAmount) {
+    // 정적 팩토리 메소드
+    public static Account create(Child child, BigDecimal initialAmount) {
         Account account = new Account();
         account.child = child;
         account.status = true;
         account.availableCash = initialAmount;
         account.totalPurchase = BigDecimal.ZERO;
 
-
-        DepositTransaction deposit = DepositTransaction.create(initialAmount, "기본금 지급", DepositTransactionType.DEPOSIT);
-        account.addDepositTransaction(deposit);
-
         return account;
-    }
-
-    // 연관관계 편의 메소드
-    public void addDepositTransaction(DepositTransaction tx) {
-        this.depositTransactions.add(tx);
-        tx.setAccount(this);
     }
 
 

--- a/domain/src/main/java/com/fintory/domain/account/model/DepositTransaction.java
+++ b/domain/src/main/java/com/fintory/domain/account/model/DepositTransaction.java
@@ -6,7 +6,6 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -29,17 +28,17 @@ public class DepositTransaction extends BaseEntity {
     private LocalDateTime occurredAt;
 
     // 연관관계 설정
-    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="account_id")
     private Account account;
 
-    public static DepositTransaction create(BigDecimal amount, String description, DepositTransactionType type) {
+    public static DepositTransaction create(BigDecimal amount, String description, DepositTransactionType type, Account account) {
         DepositTransaction dt = new DepositTransaction();
         dt.amount = amount;
         dt.description = description;
         dt.type = type;
         dt.occurredAt = LocalDateTime.now();
+        dt.account = account;
         return dt;
     }
 

--- a/domain/src/main/java/com/fintory/domain/point/model/PointTransaction.java
+++ b/domain/src/main/java/com/fintory/domain/point/model/PointTransaction.java
@@ -26,19 +26,21 @@ public class PointTransaction extends BaseEntity {
     @JoinColumn(name = "point_id")
     private PointWallet pointWallet;
 
-    private PointTransaction(int amount, PointTransactionType type, PointTransactionSource source, PointWallet pointWallet) {
-        this.amount = amount;
-        this.type = type;
-        this.source = source;
-        this.pointWallet = pointWallet;
+    public static PointTransaction createEarningTransaction(int amount, PointTransactionSource source, PointWallet pointWallet) {
+        PointTransaction pt = new PointTransaction();
+        pt.amount = amount;
+        pt.type = PointTransactionType.EARN;
+        pt.source = source;
+        pt.pointWallet = pointWallet;
+        return pt;
     }
 
-    public static PointTransaction earn(int amount, PointTransactionSource source, PointWallet pointWallet) {
-        return new PointTransaction(amount, PointTransactionType.EARN, source, pointWallet);
+    public static PointTransaction createWithdrawTransaction(int amount, PointTransactionSource source, PointWallet pointWallet) {
+        PointTransaction pt = new PointTransaction();
+        pt.amount = amount;
+        pt.type = PointTransactionType.WITHDRAW;
+        pt.source = source;
+        pt.pointWallet = pointWallet;
+        return pt;
     }
-
-    public static PointTransaction use(int amount, PointTransactionSource source, PointWallet pointWallet) {
-        return new PointTransaction(amount, PointTransactionType.WITHDRAW, source, pointWallet);
-    }
-
 }

--- a/domain/src/main/java/com/fintory/domain/point/model/PointWallet.java
+++ b/domain/src/main/java/com/fintory/domain/point/model/PointWallet.java
@@ -39,15 +39,8 @@ public class PointWallet extends BaseEntity {
         this.totalAmount += amount;
     }
 
-    public void exchangePoint(int point) {
-    }
     public void withdrawPoint(int amount) {
         this.totalAmount -= amount;
-    }
-
-    public void addTransaction(PointTransaction pt) {
-        this.transactions.add(pt);
-        pt.setPointWallet(this);
     }
 
 }

--- a/infra/src/main/java/com/fintory/infra/domain/account/serviceImpl/AccountServiceImpl.java
+++ b/infra/src/main/java/com/fintory/infra/domain/account/serviceImpl/AccountServiceImpl.java
@@ -5,6 +5,7 @@ import com.fintory.common.exception.DomainException;
 import com.fintory.domain.account.dto.response.DepositTransactionResponse;
 import com.fintory.domain.account.model.Account;
 import com.fintory.domain.account.model.DepositTransaction;
+import com.fintory.domain.account.model.DepositTransactionType;
 import com.fintory.domain.account.service.AccountService;
 import com.fintory.domain.child.model.Child;
 import com.fintory.infra.domain.account.repository.AccountRepository;
@@ -26,18 +27,26 @@ public class AccountServiceImpl implements AccountService {
     private final DepositTransactionRepository depositTransactionRepository;
 
     @Override
+    @Transactional
     public void createInitialAccount(Child child) {
+
         BigDecimal initialCash = new BigDecimal("100000");
+
         try {
-            Account account = Account.createWithInitialDeposit(child, initialCash);
+            //계좌 생성
+            Account account = Account.create(child, initialCash);
             accountRepository.save(account);
-            log.info("계좌 생성 완료: childId={}, 초기 입금={}", child.getId(), initialCash);
+
+            //초기금 입금 거래내역 생성
+            DepositTransaction deposit = DepositTransaction.create(initialCash, "기본금 지급", DepositTransactionType.DEPOSIT, account);
+            depositTransactionRepository.save(deposit);
+
         } catch (Exception e) {
             throw new DomainException(DomainErrorCode.INITIALIZE_ACCOUNT_FAILED, e);
         }
     }
 
-
+    @Override
     @Transactional(readOnly = true)
     public List<DepositTransactionResponse> getDepositTransactionsByChild(Child child) {
         Account account = accountRepository.findByChild(child)

--- a/infra/src/main/java/com/fintory/infra/domain/attendance/serviceImpl/AttendanceServiceImpl.java
+++ b/infra/src/main/java/com/fintory/infra/domain/attendance/serviceImpl/AttendanceServiceImpl.java
@@ -8,6 +8,7 @@ import com.fintory.infra.domain.attendance.repository.AttendanceRepository;
 import com.fintory.infra.domain.point.serviceimpl.PointServiceImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -21,6 +22,7 @@ public class AttendanceServiceImpl implements AttendanceService {
     private final PointServiceImpl pointService;
 
     @Override
+    @Transactional
     public int check(Child child) {
 
         LocalDate today = LocalDate.now();

--- a/infra/src/main/java/com/fintory/infra/domain/point/repository/PointTransactionRepository.java
+++ b/infra/src/main/java/com/fintory/infra/domain/point/repository/PointTransactionRepository.java
@@ -1,0 +1,9 @@
+package com.fintory.infra.domain.point.repository;
+
+import com.fintory.domain.point.model.PointTransaction;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PointTransactionRepository extends JpaRepository<PointTransaction, Long> {
+}

--- a/infra/src/main/java/com/fintory/infra/domain/point/serviceimpl/PointServiceImpl.java
+++ b/infra/src/main/java/com/fintory/infra/domain/point/serviceimpl/PointServiceImpl.java
@@ -12,7 +12,9 @@ import com.fintory.domain.point.model.PointTransactionSource;
 import com.fintory.domain.point.model.PointWallet;
 import com.fintory.domain.point.service.PointService;
 import com.fintory.infra.domain.account.repository.AccountRepository;
+import com.fintory.infra.domain.account.repository.DepositTransactionRepository;
 import com.fintory.infra.domain.point.repository.PointRepository;
+import com.fintory.infra.domain.point.repository.PointTransactionRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -26,7 +28,9 @@ import java.math.BigDecimal;
 public class PointServiceImpl implements PointService {
 
     private final PointRepository pointRepository;
+    private final PointTransactionRepository pointTransactionRepository;
     private final AccountRepository accountRepository;
+    private final DepositTransactionRepository depositTransactionRepository;
 
     @Override
     @Transactional
@@ -36,12 +40,16 @@ public class PointServiceImpl implements PointService {
         PointWallet pointWallet = pointRepository.findByChildId(child.getId())
                 .orElseThrow(() -> new IllegalStateException("포인트 지갑이 없습니다. childId=" + child.getId()));
 
+        // setter
         updatePointAccount(pointWallet, pointToGive);
-        createPointTransactions(pointWallet, pointToGive, PointTransactionSource.ATTENDANCE_POINT);
+        // 정적 팩토리 메소드
+        PointTransaction pointTransaction = PointTransaction.createEarningTransaction(pointToGive, PointTransactionSource.ATTENDANCE_POINT, pointWallet);
+        pointTransactionRepository.save(pointTransaction); // 영속성 전이 이용하지 않고 명시적으로 저장.
 
     }
 
     @Override
+    @Transactional
     public void createInitialPointWallet(Child child) {
         try {
             PointWallet wallet = PointWallet.createWithInitialPointWallet(child);
@@ -71,29 +79,33 @@ public class PointServiceImpl implements PointService {
     }
 
     @Override
+    @Transactional
     public Integer exchangePointsToCash(Child child, int point) {
-        //포인트지갑 가져오기
+
         PointWallet pointWallet = pointRepository.findByChildId(child.getId())
                 .orElseThrow(() -> new IllegalStateException("포인트 지갑이 없습니다. childId=" + child.getId()));
 
-        //현금 지갑 가져오기
-        Account account = accountRepository.findByChildId(child.getId()).orElseThrow(()-> new DomainException(DomainErrorCode.ACCOUNT_NOT_FOUND));
+        Account account = accountRepository.findByChildId(child.getId())
+                .orElseThrow(()-> new DomainException(DomainErrorCode.ACCOUNT_NOT_FOUND));
 
         if (pointWallet.getTotalAmount() < point) {
             throw new DomainException(DomainErrorCode.NOT_ENOUGH_POINT);
         }
-        //포인트 지갑 업데이트
+
+        //포인트 지갑 업데이트 -> setter
         updatePointAccountByExchange(pointWallet, point);
-        //포인트 내역 생성
-        createPointTransactions(pointWallet, point, PointTransactionSource.EXCHANGE_POINT);
-        //현금 지갑 업데이트, 보유 현금 반환
+        //포인트 내역 생성 -> 정적 팩토리 메소드
+        PointTransaction pointTransaction = PointTransaction.createWithdrawTransaction(point, PointTransactionSource.EXCHANGE_POINT, pointWallet);
+        pointTransactionRepository.save(pointTransaction);
+        //현금 지갑 업데이트, 보유 현금 반환 -> setter
         BigDecimal availableCash = updateAccountByExchange(account, BigDecimal.valueOf(point));
-        //현금 내역 생성
-        DepositTransaction.create(BigDecimal.valueOf(point), "포인트 환전", DepositTransactionType.DEPOSIT);
+        //현금 내역 생성 -> 정적 팩토리 메소드
+        DepositTransaction depositTransaction = DepositTransaction.create(BigDecimal.valueOf(point), "포인트 환전", DepositTransactionType.DEPOSIT, account);
+        depositTransactionRepository.save(depositTransaction);
+
         return availableCash.intValue();
     }
 
-    // 포인트 지갑 업데이트
     // 부모 메소드에 transactional이 적용됐기에 해당 메소드로 적용이 됨
     // 따라서 pointWallet에 영속성이 적용되고 필드를 업데이트한 내용은 transactional 종료시 자동 commit 됨
     // -> 따라서 save() 호출 불필요
@@ -105,16 +117,8 @@ public class PointServiceImpl implements PointService {
         pointWallet.withdrawPoint(point);
     }
 
-    // 포인트 거래내역 생성
-    private void createPointTransactions(PointWallet pointWallet, int point, PointTransactionSource source) {
-        PointTransaction pt = PointTransaction.earn(point, source, pointWallet);
-        // wallet의 편의 메소드
-        pointWallet.addTransaction(pt);
-    }
-
     private BigDecimal updateAccountByExchange(Account account, BigDecimal exchangePoint) {
         account.updateExchangePoint(exchangePoint);
-        Account savedAccount = accountRepository.save(account);
-        return savedAccount.getAvailableCash();
+        return account.getAvailableCash();
     }
 }

--- a/infra/src/main/java/com/fintory/infra/domain/trading/TradingServiceImpl.java
+++ b/infra/src/main/java/com/fintory/infra/domain/trading/TradingServiceImpl.java
@@ -14,6 +14,7 @@ import com.fintory.domain.stock.model.Stock;
 import com.fintory.domain.stock.service.ExchangeRateService;
 import com.fintory.domain.stock.service.TradingService;
 import com.fintory.infra.domain.account.repository.AccountRepository;
+import com.fintory.infra.domain.account.repository.DepositTransactionRepository;
 import com.fintory.infra.domain.child.repository.ChildRepository;
 import com.fintory.infra.domain.portfolio.repository.OwnedStockRepository;
 import com.fintory.infra.domain.portfolio.repository.StockTransactionRepository;
@@ -26,8 +27,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
-@Service
 @Slf4j
+@Service
 @RequiredArgsConstructor
 public class TradingServiceImpl implements TradingService {
 
@@ -37,10 +38,11 @@ public class TradingServiceImpl implements TradingService {
     private final StockRepository stockRepository;
     private final OwnedStockRepository ownedStockRepository;
     private final StockTransactionRepository stockTransactionRepository;
+    private final DepositTransactionRepository depositTransactionRepository;
 
 
-    @Transactional
     @Override
+    @Transactional
     public void trade(TradeRequest tradeRequest, String email){
         Child child = childRepository.findByEmail(email).orElseThrow(()-> new DomainException(DomainErrorCode.USER_NOT_FOUND));
         Account account = accountRepository.findByChildId(child.getId()).orElseThrow(()-> new DomainException(DomainErrorCode.ACCOUNT_NOT_FOUND));
@@ -56,7 +58,7 @@ public class TradingServiceImpl implements TradingService {
     }
 
     //주식 구매 기능
-    public void processBuyTrade(TradeRequest tradeRequest,Account account,Stock stock,BigDecimal exchangeRate){
+    private void processBuyTrade(TradeRequest tradeRequest, Account account, Stock stock, BigDecimal exchangeRate){
 
 
         TradeCalculation tradeCalculation = calculateTradeAmount(tradeRequest, stock, exchangeRate);
@@ -64,22 +66,23 @@ public class TradingServiceImpl implements TradingService {
         MarketType marketType =  tradeCalculation.marketType();
 
         //현재 account 금액을 넘지 않는지 확인
-        if(!isAvailablePurchase(account,totalTradeAmount)){
+        if(!isAvailablePurchase(account, totalTradeAmount)){
             throw new DomainException(DomainErrorCode.INSUFFICIENT_BALANCE);
         }
 
-        //ownedStock, stockTransaction 업데이트
-        updateStockAndTransactionForPurchase(tradeRequest,account,stock,totalTradeAmount,exchangeRate,marketType);
+        //ownedStock 업데이트/생성 -> setter/빌더, stockTransaction 생성 -> 빌더
+        updateStockAndTransactionForPurchase(tradeRequest, account, stock, totalTradeAmount, exchangeRate, marketType);
 
-        // 현금내역 생성, account.getDepositTransactions() 쓸일 없으면 양방향 제거 고려
-        DepositTransaction.create(totalTradeAmount.negate(), stock.getName() + "매수", DepositTransactionType.WITHDRAW);
-        //account 업데이트
-        updateAccountForPurchase(account,totalTradeAmount);
+        // 현금거래 내역 생성 -> 정적 팩토리 메소드
+        DepositTransaction depositTransaction = DepositTransaction.create(totalTradeAmount.negate(), stock.getName() + "매수", DepositTransactionType.WITHDRAW, account);
+        depositTransactionRepository.save(depositTransaction);
+        //account 업데이트 -> setter
+        updateAccountForPurchase(account, totalTradeAmount);
     }
 
 
     //주식 판매 기능
-    private void processSellTrade(TradeRequest tradeRequest,Account account, Stock stock, BigDecimal exchangeRate){
+    private void processSellTrade(TradeRequest tradeRequest, Account account, Stock stock, BigDecimal exchangeRate){
 
         TradeCalculation tradeCalculation = calculateTradeAmount(tradeRequest, stock, exchangeRate);
         BigDecimal totalTradeAmount = tradeCalculation.amount(); // 환율 적용
@@ -98,13 +101,14 @@ public class TradingServiceImpl implements TradingService {
                 .multiply(tradeRequest.quantity());
 
         //ownedStock, stockTransaction 업데이트
-        updateStockAndTransactionForSell(ownedStock,tradeRequest,account,stock,totalTradeAmount,exchangeRate,marketType,soldPurchaseAmount);
+        updateStockAndTransactionForSell(ownedStock, tradeRequest, account, stock, totalTradeAmount, exchangeRate, marketType, soldPurchaseAmount);
 
-        // 현금 내역 생성
-        DepositTransaction.create(totalTradeAmount, stock.getName() + "매도", DepositTransactionType.DEPOSIT);
+        // 현금 내역 생성 -> 정적 팩토리 메소드
+        DepositTransaction depositTransaction = DepositTransaction.create(totalTradeAmount, stock.getName() + "매도", DepositTransactionType.DEPOSIT, account);
+        depositTransactionRepository.save(depositTransaction);
 
-        //account 업데이트
-        updateAccountForSell(account,totalTradeAmount,soldPurchaseAmount);
+        //account 업데이트 -> setter
+        updateAccountForSell(account, totalTradeAmount, soldPurchaseAmount);
 
 
     }
@@ -119,26 +123,22 @@ public class TradingServiceImpl implements TradingService {
     }
 
     private void updateAccountForPurchase(Account account, BigDecimal purchasePrice){
-        // 계좌 업데이트
         account.updatePurchaseStock(purchasePrice);
-
-        accountRepository.save(account);
     }
 
-    private void updateAccountForSell(Account account, BigDecimal purchasePrice,BigDecimal soldPurchaseAmount){
+    private void updateAccountForSell(Account account, BigDecimal purchasePrice, BigDecimal soldPurchaseAmount){
         // 계좌 업데이트
-        account.updateSellStock(purchasePrice,soldPurchaseAmount);
+        account.updateSellStock(purchasePrice, soldPurchaseAmount);
 
-        accountRepository.save(account);
     }
 
 
-    private void updateStockAndTransactionForPurchase(TradeRequest tradeRequest, Account account,Stock stock, BigDecimal totalTradeAmount, BigDecimal exchangeRate,MarketType marketType){
-        OwnedStock ownedStock = ownedStockRepository.findByAccountAndStock(account,stock)
+    private void updateStockAndTransactionForPurchase(TradeRequest tradeRequest, Account account, Stock stock, BigDecimal totalTradeAmount, BigDecimal exchangeRate, MarketType marketType){
+        OwnedStock ownedStock = ownedStockRepository.findByAccountAndStock(account, stock)
                 .orElse(null);
 
         //해외 주식이면 환율 적용
-        BigDecimal averagePurchasePrice = calculatePriceWithExchange(tradeRequest.price(),marketType,exchangeRate);
+        BigDecimal averagePurchasePrice = calculatePriceWithExchange(tradeRequest.price(), marketType,exchangeRate);
 
         // 새로 구매한 주식일 경우
         if(ownedStock == null){
@@ -149,12 +149,13 @@ public class TradingServiceImpl implements TradingService {
                     .quantity(tradeRequest.quantity())
                     .averagePurchasePrice(averagePurchasePrice)
                     .build();
+
+            ownedStockRepository.save(ownedStock);
         }else{
             // 기존에 구매한 주식이 있을 경우
-            ownedStock.updateOwnedStockPurchase(tradeRequest.quantity(),totalTradeAmount);
+            ownedStock.updateOwnedStockPurchase(tradeRequest.quantity(), totalTradeAmount);
         }
 
-        ownedStockRepository.save(ownedStock);
 
         // 주식 거래 내역 업데이트
         StockTransaction stockTransaction = StockTransaction.builder()
@@ -173,10 +174,10 @@ public class TradingServiceImpl implements TradingService {
 
     }
 
-    private void updateStockAndTransactionForSell(OwnedStock ownedStock,TradeRequest tradeRequest, Account account,Stock stock, BigDecimal totalTradeAmount,
-                                                 BigDecimal exchangeRate,MarketType marketType,BigDecimal soldPurchaseAmount){
+    private void updateStockAndTransactionForSell(OwnedStock ownedStock, TradeRequest tradeRequest, Account account, Stock stock, BigDecimal totalTradeAmount,
+                                                 BigDecimal exchangeRate, MarketType marketType, BigDecimal soldPurchaseAmount){
 
-        ownedStock.updateOwnedStockSell(tradeRequest.quantity(),soldPurchaseAmount);
+        ownedStock.updateOwnedStockSell(tradeRequest.quantity(), soldPurchaseAmount);
 
         if (ownedStock.getQuantity().compareTo(BigDecimal.ZERO) == 0) {
             ownedStockRepository.delete(ownedStock);


### PR DESCRIPTION
## #️⃣연관된 이슈

#73 

## 📝작업 내용

- account, depositTransaction에 대해 리팩토링
- point, pointTransaction에 대해 리팩토링
- depositTransaction 생성시 해당 account 지정

-> 기존의 양방향 매핑 방식에서 depositTransaction에서만 account set 하는 방식으로 변경
-> 객체 생성은 정적 팩토리 메소드 이용
-> transaction에 묶여있는 경우 불필요한 save 호출 제거



