### PR TITLE
[FEAT] 보유 종목 정보 반환 api

### DIFF
--- a/app-child/src/main/java/com/fintory/child/domain/account/controller/AccountController.java
+++ b/app-child/src/main/java/com/fintory/child/domain/account/controller/AccountController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 @Tag(name = "계좌 API")
@@ -15,4 +16,7 @@ public interface AccountController {
 
     @Operation(summary = "현금 거래 전체 내역 반환")
     ResponseEntity<ApiResponse<List<DepositTransactionResponse>>> getDepositTransactionList(@AuthenticationPrincipal CustomUserDetails user);
+
+    @Operation(summary = "총 보유 현금 반환")
+    ResponseEntity<ApiResponse<BigDecimal>> getTotalCash(@AuthenticationPrincipal CustomUserDetails user);
 }

--- a/app-child/src/main/java/com/fintory/child/domain/account/controller/AccountControllerImpl.java
+++ b/app-child/src/main/java/com/fintory/child/domain/account/controller/AccountControllerImpl.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 @RestController
@@ -31,6 +32,15 @@ public class AccountControllerImpl implements AccountController{
         List<DepositTransactionResponse> list = accountService.getDepositTransactionsByChild(child);
 
         return ResponseEntity.ok(ApiResponse.ok(list));
+    }
+
+    @Override
+    @GetMapping("/total-cash")
+    public ResponseEntity<ApiResponse<BigDecimal>> getTotalCash(CustomUserDetails user) {
+        Child child = childService.getChild(user.getUsername());
+        BigDecimal totalCash = accountService.getTotalCashByChild(child);
+
+        return ResponseEntity.ok(ApiResponse.ok(totalCash));
     }
 
 }

--- a/app-child/src/main/java/com/fintory/child/domain/portfolio/controller/PortfolioController.java
+++ b/app-child/src/main/java/com/fintory/child/domain/portfolio/controller/PortfolioController.java
@@ -1,11 +1,14 @@
 package com.fintory.child.domain.portfolio.controller;
 
+import com.fintory.auth.util.CustomUserDetails;
 import com.fintory.domain.portfolio.dto.OwnedStockMetrics;
 import com.fintory.domain.portfolio.dto.PortfolioSummary;
+import com.fintory.domain.portfolio.dto.summary.PortfolioSummaryResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
 import java.util.List;
 
@@ -19,4 +22,9 @@ public interface PortfolioController {
     @Operation(summary = "보유 주식 목록 조회", description = "현재 보유 중인 모든 주식의 상세 정보를 조회합니다")
     @ApiResponse(responseCode = "200", description = "보유 주식 목록 조회 성공")
     public ResponseEntity<com.fintory.common.api.ApiResponse<List<OwnedStockMetrics>>> getOwnedStockList();
+
+    @Operation(summary = "투자 현황 조회", description = "보유 주식에 대해 가격, 수량 및 총 보유 현금 반환")
+    public ResponseEntity<com.fintory.common.api.ApiResponse<PortfolioSummaryResponse>> getPortfolioSummaryResponse(
+            @AuthenticationPrincipal CustomUserDetails user
+    );
 }

--- a/app-child/src/main/java/com/fintory/child/domain/portfolio/controller/PortfolioControllerImpl.java
+++ b/app-child/src/main/java/com/fintory/child/domain/portfolio/controller/PortfolioControllerImpl.java
@@ -1,13 +1,18 @@
 package com.fintory.child.domain.portfolio.controller;
 
 
+import com.fintory.auth.util.CustomUserDetails;
 import com.fintory.common.api.ApiResponse;
+import com.fintory.domain.child.model.Child;
+import com.fintory.domain.child.service.ChildService;
 import com.fintory.domain.portfolio.dto.OwnedStockMetrics;
 import com.fintory.domain.portfolio.dto.PortfolioSummary;
+import com.fintory.domain.portfolio.dto.summary.PortfolioSummaryResponse;
 import com.fintory.domain.portfolio.service.PortfolioService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,6 +26,7 @@ import java.util.List;
 public class PortfolioControllerImpl implements PortfolioController {
 
     private final PortfolioService portfolioService;
+    private final ChildService childService;
 
     @Override
     @GetMapping("/summary")
@@ -34,5 +40,15 @@ public class PortfolioControllerImpl implements PortfolioController {
     public ResponseEntity<ApiResponse<List<OwnedStockMetrics>>> getOwnedStockList() {
         List<OwnedStockMetrics> ownedStockMetrics = portfolioService.getOwnedStockMetrics();
         return ResponseEntity.ok(ApiResponse.ok(ownedStockMetrics));
+    }
+
+    @Override
+    @GetMapping
+    public ResponseEntity<ApiResponse<PortfolioSummaryResponse>> getPortfolioSummaryResponse(
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        Child child = childService.getChild(user.getUsername());
+        PortfolioSummaryResponse response = portfolioService.getPortfolioSummaryResponseByChild(child);
+        return ResponseEntity.ok(ApiResponse.ok(response));
     }
 }

--- a/domain/src/main/java/com/fintory/domain/account/service/AccountService.java
+++ b/domain/src/main/java/com/fintory/domain/account/service/AccountService.java
@@ -3,6 +3,7 @@ package com.fintory.domain.account.service;
 import com.fintory.domain.account.dto.response.DepositTransactionResponse;
 import com.fintory.domain.child.model.Child;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 public interface AccountService {
@@ -10,4 +11,6 @@ public interface AccountService {
     void createInitialAccount(Child child);
 
     List<DepositTransactionResponse> getDepositTransactionsByChild(Child child);
+
+    BigDecimal getTotalCashByChild(Child child);
 }

--- a/domain/src/main/java/com/fintory/domain/portfolio/dto/summary/OwnedStockDetails.java
+++ b/domain/src/main/java/com/fintory/domain/portfolio/dto/summary/OwnedStockDetails.java
@@ -1,0 +1,26 @@
+package com.fintory.domain.portfolio.dto.summary;
+
+import com.fintory.domain.portfolio.model.OwnedStock;
+import com.fintory.domain.stock.model.Stock;
+
+import java.math.BigDecimal;
+
+public record OwnedStockDetails(
+
+        String stockCode,
+        String stockName,
+
+        BigDecimal quantity,
+        BigDecimal purchaseamount
+) {
+    public static OwnedStockDetails from(OwnedStock ownedStock) {
+        Stock stock = ownedStock.getStock();
+
+        return new OwnedStockDetails(
+                stock.getCode(),
+                stock.getName(),
+                ownedStock.getQuantity(),
+                ownedStock.getPurchaseAmount()
+        );
+    }
+}

--- a/domain/src/main/java/com/fintory/domain/portfolio/dto/summary/PortfolioSummaryResponse.java
+++ b/domain/src/main/java/com/fintory/domain/portfolio/dto/summary/PortfolioSummaryResponse.java
@@ -1,0 +1,29 @@
+package com.fintory.domain.portfolio.dto.summary;
+
+import com.fintory.domain.account.model.Account;
+import com.fintory.domain.portfolio.model.OwnedStock;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record PortfolioSummaryResponse(
+
+        BigDecimal availableCash,
+        List<OwnedStockDetails>  ownedStockDetails
+) {
+
+    public static PortfolioSummaryResponse from(
+            Account account,
+            List<OwnedStock> ownedStocks
+    ) {
+        List<OwnedStockDetails> stockDetails = ownedStocks.stream()
+                .map(OwnedStockDetails::from)
+                .collect(Collectors.toList());
+
+        return new PortfolioSummaryResponse(
+                account.getAvailableCash(),
+                stockDetails
+        );
+    }
+}

--- a/domain/src/main/java/com/fintory/domain/portfolio/service/PortfolioService.java
+++ b/domain/src/main/java/com/fintory/domain/portfolio/service/PortfolioService.java
@@ -1,7 +1,10 @@
 package com.fintory.domain.portfolio.service;
 
+import com.fintory.domain.child.model.Child;
 import com.fintory.domain.portfolio.dto.OwnedStockMetrics;
 import com.fintory.domain.portfolio.dto.PortfolioSummary;
+import com.fintory.domain.portfolio.dto.summary.PortfolioSummaryResponse;
+
 import java.util.List;
 
 /**
@@ -18,7 +21,7 @@ public interface PortfolioService {
      * @return 보유 주식 지표(평균매수가, 총 수량) 및 거래 내역 리스트
      * @throws DomainException 계정을 찾을 수 없거나 조회 중 에러 발생시
      */
-    public List<OwnedStockMetrics> getOwnedStockMetrics();
+    List<OwnedStockMetrics> getOwnedStockMetrics();
 
     /**
      *
@@ -27,5 +30,7 @@ public interface PortfolioService {
      * @return 포트폴리오 요약 정보 (총 매수금액, 총 자산)
      * @throws DomainException 계정을 찾을 수 없거나 계산 중 에러 발생시
      */
-    public PortfolioSummary getPortfolioSummary();
+    PortfolioSummary getPortfolioSummary();
+
+    PortfolioSummaryResponse getPortfolioSummaryResponseByChild(Child  child);
 }

--- a/infra/src/main/java/com/fintory/infra/domain/account/serviceImpl/AccountServiceImpl.java
+++ b/infra/src/main/java/com/fintory/infra/domain/account/serviceImpl/AccountServiceImpl.java
@@ -59,4 +59,12 @@ public class AccountServiceImpl implements AccountService {
                 .map(DepositTransactionResponse::from)
                 .toList();
     }
+
+    @Override
+    public BigDecimal getTotalCashByChild(Child child) {
+        Account account = accountRepository.findByChild(child)
+                .orElseThrow(() -> new DomainException(DomainErrorCode.ACCOUNT_NOT_FOUND));
+
+        return account.getAvailableCash();
+    }
 }

--- a/infra/src/main/java/com/fintory/infra/domain/portfolio/repository/OwnedStockRepository.java
+++ b/infra/src/main/java/com/fintory/infra/domain/portfolio/repository/OwnedStockRepository.java
@@ -3,7 +3,9 @@ package com.fintory.infra.domain.portfolio.repository;
 import com.fintory.domain.account.model.Account;
 import com.fintory.domain.portfolio.model.OwnedStock;
 import com.fintory.domain.stock.model.Stock;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -12,6 +14,9 @@ import java.util.Optional;
 @Repository
 public interface OwnedStockRepository extends JpaRepository<OwnedStock,Long> {
     List<OwnedStock> findByAccount(Account account);
+
+    @Query("SELECT os FROM OwnedStock os JOIN FETCH os.stock WHERE os.account = :account")
+    List<OwnedStock> findAllWithStockByAccount(@Param("account") Account account);
 
     Optional<OwnedStock> findByAccountAndStock(Account account, Stock stock);
 }

--- a/infra/src/main/java/com/fintory/infra/domain/portfolio/serviceImpl/PortfolioServiceImpl.java
+++ b/infra/src/main/java/com/fintory/infra/domain/portfolio/serviceImpl/PortfolioServiceImpl.java
@@ -3,10 +3,9 @@ package com.fintory.infra.domain.portfolio.serviceImpl;
 import com.fintory.common.exception.DomainErrorCode;
 import com.fintory.common.exception.DomainException;
 import com.fintory.domain.account.model.Account;
-import com.fintory.domain.portfolio.dto.OwnedStockMetrics;
-import com.fintory.domain.portfolio.dto.PortfolioSummary;
-import com.fintory.domain.portfolio.dto.StockMetricsResult;
-import com.fintory.domain.portfolio.dto.StockTransactionInfo;
+import com.fintory.domain.child.model.Child;
+import com.fintory.domain.portfolio.dto.*;
+import com.fintory.domain.portfolio.dto.summary.PortfolioSummaryResponse;
 import com.fintory.domain.portfolio.model.OwnedStock;
 import com.fintory.domain.portfolio.model.StockTransaction;
 import com.fintory.domain.portfolio.model.TransactionType;
@@ -101,6 +100,15 @@ public class PortfolioServiceImpl implements PortfolioService {
             log.error("포트폴리오 요약 조회 시 에러 발생: {}", e.getMessage());
             throw new DomainException(DomainErrorCode.PORTFOLIO_CALCULATION_ERROR);
         }
+    }
+
+    public PortfolioSummaryResponse getPortfolioSummaryResponseByChild(Child child) {
+        Account account = accountRepository.findByChild(child)
+                .orElseThrow(() -> new DomainException(DomainErrorCode.ACCOUNT_NOT_FOUND));
+
+        List<OwnedStock> ownedStocks = ownedStockRepository.findAllWithStockByAccount(account);
+
+        return PortfolioSummaryResponse.from(account, ownedStocks);
     }
 
     //현재가 조회 메소드


### PR DESCRIPTION
## 📝작업 내용
- 클라이언트에서 메트릭 계산을 위해 사용할 보유 주식 종목에 대한 정보 반환
- (구매 수량 리스트, 총구매 가격 리스트) + 총보유 현금
- 총매수 -> 총구매 가격의 총합
- 총 평가금액 -> (개별 구매 수량 X 현재가)의 합 + 총보유 현금
- 총 수익률 -> 총 평가 금액 / 총 매수
- 총보유 현금 반환 api 따로 추가로 생성

### 스크린샷 (선택)
<img width="261" height="331" alt="스크린샷 2025-10-10 오후 9 25 00" src="https://github.com/user-attachments/assets/eb8f1e4c-86d5-46ae-86b5-3b7f5faf2c42" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- 기존의 메소드 및 dto랑 완전 무관하게 작성했습니다. 그대로 사용하셔도 좋고 기존의 메서드를 유사한 방식으로 수정하셔도 좋을 것 같습니다
- account로 ownedStock 찾는 쿼리메소드도 기존의 메소드와 기능은 동일하지만, N+1발생하여 fetchjoin적용하여 새로 작성했습니다
