### PR TITLE
[FEAT] 알림 기능 구현

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,6 +95,7 @@ jobs:
             export OPENAI_MODEL=${{ secrets.OPENAI_MODEL}}
             export OPENAI_TEMPERATURE=${{secrets.OPENAI_TEMPERATURE}}
             export OPENAI_MAX_TOKENS=${{secrets.OPENAI_MAX_TOKENS}}
+            export FIREBASE_CONFIG=${{secrets.FIREBASE_CONFIG}}
             
             aws ecr get-login-password --region ap-northeast-2 | \
               docker login --username AWS --password-stdin ${{ steps.login-ecr.outputs.registry }}
@@ -105,4 +106,4 @@ jobs:
             docker compose up -d
 
             docker image prune -f
-
+            

--- a/app-child/src/main/java/com/fintory/child/domain/alarm/controller/AlarmController.java
+++ b/app-child/src/main/java/com/fintory/child/domain/alarm/controller/AlarmController.java
@@ -1,0 +1,22 @@
+package com.fintory.child.domain.alarm.controller;
+
+import com.fintory.auth.util.CustomUserDetails;
+import com.fintory.common.api.ApiResponse;
+import com.fintory.domain.alarm.dto.FcmTokenRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name="알림 API")
+public interface AlarmController {
+
+    @Operation(summary="백엔드에게 FCM 토큰 전달")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200",description = "FCM 토큰 전달")
+    ResponseEntity<ApiResponse<Void>> saveToken(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestBody FcmTokenRequest request);
+    
+    @Operation(summary = "로그아웃 시 FCM 토큰 삭제")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200",description = "FCM 토큰 삭제")
+    ResponseEntity<ApiResponse<Void>> deleteToken(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestBody FcmTokenRequest request);
+}

--- a/app-child/src/main/java/com/fintory/child/domain/alarm/controller/AlarmControllerImpl.java
+++ b/app-child/src/main/java/com/fintory/child/domain/alarm/controller/AlarmControllerImpl.java
@@ -1,0 +1,37 @@
+package com.fintory.child.domain.alarm.controller;
+
+import com.fintory.auth.util.CustomUserDetails;
+import com.fintory.common.api.ApiResponse;
+import com.fintory.common.exception.DomainErrorCode;
+import com.fintory.common.exception.DomainException;
+import com.fintory.domain.alarm.dto.FcmTokenRequest;
+import com.fintory.domain.alarm.service.AlarmService;
+import com.fintory.domain.child.model.Child;
+import com.fintory.infra.domain.child.repository.ChildRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("api/child/alarm")
+@RequiredArgsConstructor
+public class AlarmControllerImpl {
+
+    private final AlarmService alarmService;
+    private final ChildRepository childRepository;
+
+    @PostMapping("/token")
+    public ResponseEntity<ApiResponse<Void>> saveToken(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestBody FcmTokenRequest request){
+        Child child = childRepository.findByEmail(userDetails.getUsername()).orElseThrow(()-> new DomainException(DomainErrorCode.USER_NOT_FOUND));
+        alarmService.saveToken(child,request.token());
+        return ResponseEntity.ok(ApiResponse.ok(null));
+    }
+
+    // Controller
+    @DeleteMapping("/token")
+    public ResponseEntity<ApiResponse<Void>> deleteToken(@RequestBody FcmTokenRequest request) {
+        alarmService.deleteToken(request.token());
+        return ResponseEntity.ok(ApiResponse.ok(null));
+    }
+}

--- a/app-child/src/main/resources/application-deploy.yml
+++ b/app-child/src/main/resources/application-deploy.yml
@@ -91,3 +91,6 @@ db-openapi:
 
 eos:
   api-key: ${EOS_API_KEY}
+
+firebase:
+  config: ${FIREBASE_CONFIG}

--- a/app-child/src/main/resources/application-local.yml
+++ b/app-child/src/main/resources/application-local.yml
@@ -98,7 +98,8 @@ db-openapi:
   db-appsecret: ${DB_APPSECRET}
   base-url: https://openapi.dbsec.co.kr:8443
 
-
+firebase:
+  config: ${FIREBASE_CONFIG}
 
 
 

--- a/common/src/main/java/com/fintory/common/exception/DomainErrorCode.java
+++ b/common/src/main/java/com/fintory/common/exception/DomainErrorCode.java
@@ -21,13 +21,13 @@ public enum DomainErrorCode {
     LOGINED_USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "LOGINED_USER_NOT_FOUND", "사용자가 로그인되어 있지 않습니다" ),
     WRONG_EMAIL_OR_PASSWORD(HttpStatus.BAD_REQUEST, "WRONG_EMAIL_OR_PASSWORD", "아이디 또는 비밀번호가 일치하지 않습니다."),
     ALREADY_REGISTERED_EMAIL(HttpStatus.BAD_REQUEST, "ALREADY_REGISTERED_EMAILALREADY_REGISTERED_EMAIL", "해당 이메일로 가입된 계정이 있습니다. 다른 이메일을 사용하거나 다른 방식으로 로그인 해주세요"),
-
     //account
     INITIALIZE_ACCOUNT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "INITIALIZE_ACCOUNT_FAILED", "계좌 생성 및 초기화 실패"),
 
     //point
     INITIALIZE_POINT_WALLET_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "INITIALIZE_POINT_WALLET_FAILED", "포인트 지갑 생성 및 초기화 실패"),
     NOT_ENOUGH_POINT(HttpStatus.BAD_REQUEST, "NOT_ENOUGH_POINT", "보유한 포인트가 부족합니다"),
+
 
     //jwt
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "INVALID_TOKEN", "유효하지 않은 토큰입니다."),
@@ -76,6 +76,12 @@ public enum DomainErrorCode {
 
     //live stock price
     LIVE_STOCK_PRICE_NOT_FOUND(HttpStatus.NOT_FOUND,"LIVE_STOCK_PRICE_NOT_FOUND","현재가 데이터를 찾을 수 없습니다."),
+
+    //alarm
+    FIREBASE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"FIREBASE_ERROR","Firebase 앱 초기화 중 에러가 발생했습니다"),
+    FCMTOKEN_EMPTY(HttpStatus.NOT_FOUND,"FCMTOKEN_EMPTY","해당 CHILD에게 부여된 FCM 토큰이 없습니다."),
+    FCM_SEND_FAILED(HttpStatus.SERVICE_UNAVAILABLE,"FCM_SEND_FAILED","알림 푸시하는 과정에서 오류가 발생"),
+
 
     // price alert
     PRICE_ALERT_NOT_FOUND(HttpStatus.NOT_FOUND,"PRICE_ALERT_NOT_FOUND","해당 감시가 데이터를 찾을 수 없습니다"),

--- a/domain/src/main/java/com/fintory/domain/alarm/dto/FcmTokenRequest.java
+++ b/domain/src/main/java/com/fintory/domain/alarm/dto/FcmTokenRequest.java
@@ -1,0 +1,10 @@
+package com.fintory.domain.alarm.dto;
+
+
+import jakarta.validation.constraints.NotBlank;
+
+public record FcmTokenRequest(
+        @NotBlank(message="토큰을 입력해야 합니다.")
+        String token
+) {
+}

--- a/domain/src/main/java/com/fintory/domain/alarm/model/FcmToken.java
+++ b/domain/src/main/java/com/fintory/domain/alarm/model/FcmToken.java
@@ -1,0 +1,34 @@
+package com.fintory.domain.alarm.model;
+
+import com.fintory.domain.child.model.Child;
+import com.fintory.domain.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+/*
+*
+* 한 명의 사용자가 여러 기기에서 로그인하면 모든 기기에 알림을 보내줘야 함
+* 따라서 FcmToken을 child에서 list 형식으로 가짐
+*
+* */
+public class FcmToken extends BaseEntity {
+
+    @Column(nullable=false)
+    private String token;
+
+    @ManyToOne
+    @JoinColumn(name="child_id")
+    private Child child;
+
+}

--- a/domain/src/main/java/com/fintory/domain/alarm/model/NotificationType.java
+++ b/domain/src/main/java/com/fintory/domain/alarm/model/NotificationType.java
@@ -1,0 +1,8 @@
+package com.fintory.domain.alarm.model;
+
+public enum NotificationType {
+    ATTENDENCE,
+    REPORT,
+    RANKING,
+    PRICE_ALERT
+}

--- a/domain/src/main/java/com/fintory/domain/alarm/service/AlarmService.java
+++ b/domain/src/main/java/com/fintory/domain/alarm/service/AlarmService.java
@@ -1,0 +1,16 @@
+package com.fintory.domain.alarm.service;
+
+import com.fintory.domain.alarm.model.NotificationType;
+import com.fintory.domain.child.model.Child;
+
+
+public interface AlarmService {
+
+     void saveToken(Child child, String token);
+
+     void pushMessage(Long childId,NotificationType notificationType,
+                            String title,
+                            String body);
+
+     void deleteToken(String token);
+}

--- a/domain/src/main/java/com/fintory/domain/child/model/Child.java
+++ b/domain/src/main/java/com/fintory/domain/child/model/Child.java
@@ -2,6 +2,7 @@ package com.fintory.domain.child.model;
 
 import com.fintory.domain.account.model.Account;
 import com.fintory.domain.alarm.model.Alarm;
+import com.fintory.domain.alarm.model.FcmToken;
 import com.fintory.domain.attendence.model.AttendanceLog;
 import com.fintory.domain.challenge.model.Challenge;
 import com.fintory.domain.common.BaseEntity;
@@ -93,5 +94,8 @@ public class Child extends BaseEntity implements User {
 
     @OneToMany(cascade = CascadeType.ALL, mappedBy = "child")
     private List<PriceAlert> priceAlerts;
+
+    @OneToMany(cascade = CascadeType.ALL, mappedBy = "child")
+    private List<FcmToken> fcmTokens;
 
 }

--- a/infra/build.gradle
+++ b/infra/build.gradle
@@ -94,7 +94,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-batch'
     implementation 'org.springframework.boot:spring-boot-starter-quartz'
 
+    /* fcm */
+    implementation 'com.google.firebase:firebase-admin:9.2.0'
 
+    /* Spring Security */
+    implementation 'org.springframework.boot:spring-boot-starter-security'
 }
 
 bootJar{

--- a/infra/src/main/java/com/fintory/infra/domain/alarm/config/FirebaseConfig.java
+++ b/infra/src/main/java/com/fintory/infra/domain/alarm/config/FirebaseConfig.java
@@ -1,0 +1,41 @@
+package com.fintory.infra.domain.alarm.config;
+
+
+import com.fintory.common.exception.DomainErrorCode;
+import com.fintory.common.exception.DomainException;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.InputStream;
+
+/* firebase 서비스를 이용하기 위한 연결 설정 */
+@Configuration
+@Slf4j
+public class FirebaseConfig {
+
+    @PostConstruct
+    public void init(){
+        try{
+            // firebase 설정 파일 로드
+            InputStream serviceAccount = new ClassPathResource("firebaseConfig.json").getInputStream();
+
+            // firebase 인증 정보 설정
+            FirebaseOptions options = new FirebaseOptions.Builder()
+                    .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                    .build();
+
+            // firebase 앱 초기화
+            if(FirebaseApp.getApps().isEmpty()){
+                FirebaseApp.initializeApp(options);
+            }
+        }catch(Exception e){
+            log.error("firebase 초기화 실패",e);
+            throw new DomainException(DomainErrorCode.FIREBASE_ERROR);
+        }
+    }
+}

--- a/infra/src/main/java/com/fintory/infra/domain/alarm/config/FirebaseConfig.java
+++ b/infra/src/main/java/com/fintory/infra/domain/alarm/config/FirebaseConfig.java
@@ -8,9 +8,11 @@ import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 
 /* firebase 서비스를 이용하기 위한 연결 설정 */
@@ -18,11 +20,14 @@ import java.io.InputStream;
 @Slf4j
 public class FirebaseConfig {
 
+    @Value("${firebase.config}")
+    private String firebaseConfig;
+
     @PostConstruct
     public void init(){
         try{
             // firebase 설정 파일 로드
-            InputStream serviceAccount = new ClassPathResource("firebaseConfig.json").getInputStream();
+            InputStream serviceAccount = new ByteArrayInputStream(firebaseConfig.getBytes());
 
             // firebase 인증 정보 설정
             FirebaseOptions options = new FirebaseOptions.Builder()

--- a/infra/src/main/java/com/fintory/infra/domain/alarm/event/PriceAlertEvent.java
+++ b/infra/src/main/java/com/fintory/infra/domain/alarm/event/PriceAlertEvent.java
@@ -1,0 +1,17 @@
+package com.fintory.infra.domain.alarm.event;
+
+import com.fintory.domain.stock.dto.websocket.LiveStockPriceStream;
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+public class PriceAlertEvent extends ApplicationEvent {
+
+    private final LiveStockPriceStream stockPriceStream;
+
+
+    public PriceAlertEvent(Object source, LiveStockPriceStream stockPriceStream) {
+        super(source);
+        this.stockPriceStream = stockPriceStream;
+    }
+}

--- a/infra/src/main/java/com/fintory/infra/domain/alarm/repository/FcmTokenRepository.java
+++ b/infra/src/main/java/com/fintory/infra/domain/alarm/repository/FcmTokenRepository.java
@@ -1,0 +1,17 @@
+package com.fintory.infra.domain.alarm.repository;
+
+import com.fintory.domain.alarm.model.FcmToken;
+import com.fintory.domain.child.model.Child;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface FcmTokenRepository extends JpaRepository<FcmToken, String> {
+    List<FcmToken> findByChild(Child child);
+
+    boolean existsByToken(String token);
+
+    void deleteByToken(String token);
+}

--- a/infra/src/main/java/com/fintory/infra/domain/alarm/repository/PriceAlertRepository.java
+++ b/infra/src/main/java/com/fintory/infra/domain/alarm/repository/PriceAlertRepository.java
@@ -1,6 +1,7 @@
 package com.fintory.infra.domain.alarm.repository;
 
 import com.fintory.domain.alarm.model.PriceAlert;
+import com.fintory.domain.child.model.Child;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.math.BigDecimal;
@@ -11,4 +12,7 @@ public interface PriceAlertRepository extends JpaRepository<PriceAlert,Long> {
     List<PriceAlert> findByChildIdAndStockCode(Long id, String stockCode);
     boolean existsByChildIdAndStockCodeAndTargetPrice(Long id, String code, BigDecimal bigDecimal);
 
+    List<PriceAlert> findByChildAndTargetPrice(Child child, BigDecimal currentPrice);
+
+    List<PriceAlert> findByStockCode(String code);
 }

--- a/infra/src/main/java/com/fintory/infra/domain/alarm/serviceImpl/AlarmServiceImpl.java
+++ b/infra/src/main/java/com/fintory/infra/domain/alarm/serviceImpl/AlarmServiceImpl.java
@@ -1,0 +1,112 @@
+package com.fintory.infra.domain.alarm.serviceImpl;
+
+
+import com.fintory.common.exception.DomainErrorCode;
+import com.fintory.common.exception.DomainException;
+import com.fintory.domain.alarm.model.FcmToken;
+import com.fintory.domain.alarm.model.NotificationType;
+import com.fintory.domain.alarm.service.AlarmService;
+import com.fintory.domain.child.model.Child;
+import com.fintory.infra.domain.alarm.repository.FcmTokenRepository;
+import com.fintory.infra.domain.child.repository.ChildRepository;
+import com.fintory.infra.util.SecurityUtil;
+import com.google.cloud.storage.Acl;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AlarmServiceImpl implements AlarmService {
+
+    private final FcmTokenRepository fcmTokenRepository;
+    private final SecurityUtil securityUtil;
+    private final ChildRepository childRepository;
+
+    //프론트에서 받은 토큰을 DB에 저장하는 메소드
+    @Override
+    @Transactional
+    public void saveToken(Child child, String token){
+
+        //토큰 중복 저장 방지
+        if(fcmTokenRepository.existsByToken(token)){
+            log.info("이미 존재하는 FCM 토큰:{}", token);
+            return;
+        }
+        FcmToken fcmToken = FcmToken.builder()
+                .token(token).child(child)
+                .build();
+
+        fcmTokenRepository.save(fcmToken);
+    }
+
+    //fcm에게 푸시 알림 전송
+    @Override
+    @Transactional(readOnly = true)
+    public void pushMessage(Long childId,
+                            NotificationType notificationType,
+                            String title,
+                            String body){
+
+        Child child = childRepository.findById(childId).orElseThrow(()-> new DomainException(DomainErrorCode.USER_NOT_FOUND));
+        List<FcmToken> fcmTokens = getToken(child);
+
+        if(fcmTokens.isEmpty()){
+            throw new DomainException(DomainErrorCode.FCMTOKEN_EMPTY);
+        }
+
+        // 모든 기기에 알림 전송
+        for(FcmToken fcmToken : fcmTokens) {
+            sendToDevice(fcmToken.getToken(),notificationType, title, body);
+        }
+    }
+
+    @Override
+    @Transactional
+    public void deleteToken( String token){
+        fcmTokenRepository.deleteByToken(token);
+        log.info("FCM 토큰 삭제:{}", token);
+    }
+
+    private void sendToDevice(String fcmToken, NotificationType notificationType, String title, String body){
+
+        //fcm 메시지 생성
+        Message message = Message.builder()
+                .setToken(fcmToken)
+                .setNotification(Notification.builder()
+                        .setTitle(title)
+                        .setBody(body)
+                        .build())
+                .putData("type",notificationType.name())
+                .build();
+
+
+        //fcm 서버로 전송
+        try {
+            String response = FirebaseMessaging.getInstance().send(message);
+            log.info("fcm 요청 후 받은 응답:{} ",response); //테스트 로그 -> 이후 삭제
+        }catch (FirebaseMessagingException e){
+            // 예외를 던지면 다른 디바이스에도 영향을 줌
+            log.info("fcm 전송 실패(토큰 만료) "+e.getMessage());
+            deleteToken(fcmToken);
+        }
+    }
+
+    //토큰 가져오기
+    private List<FcmToken> getToken(Child child){
+        List<FcmToken> tokens = fcmTokenRepository.findByChild(child);
+        return tokens;
+    }
+
+
+
+}

--- a/infra/src/main/java/com/fintory/infra/domain/alarm/serviceImpl/AlarmServiceImpl.java
+++ b/infra/src/main/java/com/fintory/infra/domain/alarm/serviceImpl/AlarmServiceImpl.java
@@ -10,7 +10,6 @@ import com.fintory.domain.child.model.Child;
 import com.fintory.infra.domain.alarm.repository.FcmTokenRepository;
 import com.fintory.infra.domain.child.repository.ChildRepository;
 import com.fintory.infra.util.SecurityUtil;
-import com.google.cloud.storage.Acl;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;

--- a/infra/src/main/java/com/fintory/infra/domain/alarm/serviceImpl/PriceAlertEventListener.java
+++ b/infra/src/main/java/com/fintory/infra/domain/alarm/serviceImpl/PriceAlertEventListener.java
@@ -1,0 +1,119 @@
+package com.fintory.infra.domain.alarm.serviceImpl;
+
+import com.fintory.domain.alarm.model.NotificationType;
+import com.fintory.domain.alarm.model.PriceAlert;
+import com.fintory.domain.alarm.service.AlarmService;
+import com.fintory.infra.domain.alarm.event.PriceAlertEvent;
+import com.fintory.infra.domain.alarm.repository.PriceAlertRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PriceAlertEventListener {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final PriceAlertRepository priceAlertRepository;
+    private final AlarmService alarmService;
+
+
+    @Async("alertExecutor")
+    @EventListener
+    @Transactional
+    public void handlePriceAlert(PriceAlertEvent event){
+
+        String stockCode = event.getStockPriceStream().code();
+        BigDecimal currentPrice = event.getStockPriceStream().currentPrice();
+
+        String cachedKey = "priceAlert:"+stockCode;
+        List<PriceAlert> priceAlertList = getPriceAlertFromCache(cachedKey,stockCode);
+
+        // 감시가 설정 없음
+        if(priceAlertList == null){
+            return;
+        }
+        priceAlertList.forEach(alert->{
+            try {
+                checkAndSendPriceAlert(alert, stockCode, currentPrice, cachedKey);
+            }catch (Exception e){
+                log.error("감시가 알림 처리 실패",e);
+                //로그만 찍고 계속 진행
+            }
+            });
+    }
+
+
+    private List<PriceAlert> getPriceAlertFromCache(String cachedKey, String stockCode){
+        List<PriceAlert> cached = (List<PriceAlert>) redisTemplate.opsForValue().get(cachedKey);
+
+        if (cached == null || cached.isEmpty()){
+            //cache miss - db 조회
+            List<PriceAlert> priceAlertList = priceAlertRepository.findByStockCode(stockCode);
+
+            //감시가 목록이 없으면 null 반환
+            if(priceAlertList == null || priceAlertList.isEmpty()){
+                return null;
+            }
+            //Redis에서 캐싱 (10분)
+            redisTemplate.opsForValue().set(cachedKey,priceAlertList, Duration.ofMinutes(10));
+
+            return priceAlertList;
+        }
+
+        return cached;
+    }
+
+
+    private void checkAndSendPriceAlert(PriceAlert priceAlert, String stockCode, BigDecimal currentPrice, String cachedKey){
+
+
+        BigDecimal rangeMultiplier = BigDecimal.valueOf(0.01);
+        BigDecimal range = priceAlert.getTargetPrice().multiply(rangeMultiplier);
+
+        BigDecimal minPrice = priceAlert.getTargetPrice().subtract(range);
+        BigDecimal maxPrice = priceAlert.getTargetPrice().add(range);
+
+        //범위 체크
+        boolean isInRange = currentPrice.compareTo(minPrice) >= 0
+                && currentPrice.compareTo(maxPrice) <= 0;
+
+        if (!isInRange) {
+            return; // 범위 밖
+        }
+
+        // 알림 발송
+        String message = String.format(
+                "%s이(가) 감시가 %,d원 근처에 도달했습니다! (현재가: %s원)",
+                priceAlert.getStock().getName(),
+                priceAlert.getTargetPrice().intValue(),
+                currentPrice.intValue()
+        );
+
+        alarmService.pushMessage(
+                priceAlert.getChild().getId(),
+                NotificationType.PRICE_ALERT,
+                "감시가 알림",
+                message
+        );
+
+        // REVIEW 1회성 처리: 삭제
+        priceAlertRepository.delete(priceAlert);
+
+        // Redis 캐시 무효화
+        redisTemplate.delete(cachedKey);
+
+        log.info("priceAlert 발송 : childId = {}, stock={}, targetPrice={}원, currentPrice={}원",
+                priceAlert.getChild().getId(), stockCode, priceAlert.getTargetPrice(), currentPrice);
+
+    }
+}

--- a/infra/src/main/java/com/fintory/infra/domain/alarm/serviceImpl/PriceAlertEventListener.java
+++ b/infra/src/main/java/com/fintory/infra/domain/alarm/serviceImpl/PriceAlertEventListener.java
@@ -22,7 +22,7 @@ import java.util.List;
 @Slf4j
 public class PriceAlertEventListener {
 
-    private final RedisTemplate<String, Object> redisTemplate;
+    private final RedisTemplate<Object, Object> redisTemplate;
     private final PriceAlertRepository priceAlertRepository;
     private final AlarmService alarmService;
 

--- a/infra/src/main/java/com/fintory/infra/domain/alarm/serviceImpl/PriceAlertServiceImpl.java
+++ b/infra/src/main/java/com/fintory/infra/domain/alarm/serviceImpl/PriceAlertServiceImpl.java
@@ -12,7 +12,6 @@ import com.fintory.infra.domain.alarm.repository.PriceAlertRepository;
 import com.fintory.infra.domain.stock.repository.StockRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.openqa.selenium.devtools.v85.schema.model.Domain;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/infra/src/main/java/com/fintory/infra/domain/consulting/config/ReportBatchConfig.java
+++ b/infra/src/main/java/com/fintory/infra/domain/consulting/config/ReportBatchConfig.java
@@ -1,5 +1,7 @@
 package com.fintory.infra.domain.consulting.config;
 
+import com.fintory.domain.alarm.model.NotificationType;
+import com.fintory.domain.alarm.service.AlarmService;
 import com.fintory.domain.child.model.Child;
 import com.fintory.domain.consulting.service.ConsultingService;
 import com.fintory.domain.portfolio.model.StockTransaction;
@@ -22,6 +24,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.util.List;
@@ -37,6 +40,7 @@ public class ReportBatchConfig {
     private final StockTransactionRepository stockTransactionRepository;
     private final ChildRepository childRepository;
     private final ReportRepository reportRepository;
+    private final AlarmService alarmService;
 
     // Batch Job 설정
     @Bean
@@ -109,6 +113,8 @@ public class ReportBatchConfig {
             // processor에서 이미 저장이 완료되므로 로그만 기록
             children.forEach(child -> {
                 if (child != null) {
+                    LocalDate now =  LocalDate.now();
+                    alarmService.pushMessage(child.getId(),NotificationType.REPORT,now + "자 Report 생성","Report가 생성되었습니다. 와서 확인하세요");
                     log.info("리포트 생성 성공 for child: {}", child.getId());
                 }
             });

--- a/infra/src/main/java/com/fintory/infra/domain/stock/service/korean/KoreanStockServiceImpl.java
+++ b/infra/src/main/java/com/fintory/infra/domain/stock/service/korean/KoreanStockServiceImpl.java
@@ -52,17 +52,10 @@ public class KoreanStockServiceImpl implements KoreanStockService {
 
 
     private void initializeAllStockData() {
-        executeWithErrorHandling("주식 랭킹",this::initiateStockRankWithRetry);
-        sleepSafely(3000);
         executeWithErrorHandling("현재가 데이터",this::initiateLiveStockPriceWithRetry);
         sleepSafely(3000);
         executeWithErrorHandling("기간별 시세",this::initiateStockPriceHistoryWithRetry);
         sleepSafely(3000);
-    }
-
-
-    private void initiateStockRankWithRetry() {
-        koreanStockRankService.initiateKoreanStockRank();
     }
 
     private void initiateLiveStockPriceWithRetry() {

--- a/infra/src/main/java/com/fintory/infra/domain/stock/service/overseas/OverseasStockServiceImpl.java
+++ b/infra/src/main/java/com/fintory/infra/domain/stock/service/overseas/OverseasStockServiceImpl.java
@@ -67,8 +67,6 @@ public class OverseasStockServiceImpl implements OverseasStockService {
     }
 
     private void initializeAllStockData() {
-            executeWithErrorHandling("주식 랭킹",this::initiateStockRankWithRetry);
-            sleepSafely(1000);
 
             executeWithErrorHandling("현재가 데이터",this::initiateLiveStockPriceWithRetry);
             sleepSafely(1000);
@@ -78,9 +76,6 @@ public class OverseasStockServiceImpl implements OverseasStockService {
     }
 
     //@Retryable도 프록시 기반 AOP => 내부 자기 호출 + private은 @Retryable 적용x
-    public void initiateStockRankWithRetry() {
-        overseasStockRankService.initiateOverseasStockRank();
-    }
     public void initiateLiveStockPriceWithRetry() {
         overseasLiveStockPriceService.initLiveStockPrice();
     }

--- a/infra/src/main/java/com/fintory/infra/domain/stock/service/websocket/LiveStockPriceWebsocketServiceImpl.java
+++ b/infra/src/main/java/com/fintory/infra/domain/stock/service/websocket/LiveStockPriceWebsocketServiceImpl.java
@@ -7,6 +7,7 @@ import com.fintory.domain.stock.dto.websocket.MarketStatusResponse;
 import com.fintory.domain.stock.model.Stock;
 import com.fintory.domain.stock.service.websocket.LiveStockPriceWebSocketSaverService;
 import com.fintory.domain.stock.service.websocket.LiveStockPriceWebsocketService;
+import com.fintory.infra.domain.alarm.event.PriceAlertEvent;
 import com.fintory.infra.domain.stock.handler.KoreanLiveStockPriceWebSocketHandler;
 import com.fintory.infra.domain.stock.handler.OverseasLiveStockPriceWebSocketHandler;
 import com.fintory.infra.domain.stock.repository.StockRepository;
@@ -15,6 +16,7 @@ import jakarta.annotation.PreDestroy;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -70,6 +72,8 @@ public class LiveStockPriceWebsocketServiceImpl implements LiveStockPriceWebsock
 
     private final LiveStockPriceWebSocketSaverService liveStockPriceWebSocketSaverService;
 
+    //이벤트
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     public LiveStockPriceWebsocketServiceImpl(
             @Qualifier("koreanLiveStockPriceWebSocketConnectionManager") WebSocketConnectionManager koreanConnectionManager,
@@ -77,7 +81,7 @@ public class LiveStockPriceWebsocketServiceImpl implements LiveStockPriceWebsock
             KoreanLiveStockPriceWebSocketHandler koreanHandler,
             OverseasLiveStockPriceWebSocketHandler overseasHandler,
             StockRepository stockRepository,
-            SimpMessagingTemplate messageTemplate, RestTemplate restTemplate, RedisTemplate<Object, Object> redisTemplate, LiveStockPriceWebSocketSaverService liveStockPriceWebSocketSaverService) {
+            SimpMessagingTemplate messageTemplate, RestTemplate restTemplate, RedisTemplate<Object, Object> redisTemplate, LiveStockPriceWebSocketSaverService liveStockPriceWebSocketSaverService, ApplicationEventPublisher applicationEventPublisher) {
 
         this.koreanConnectionManager = koreanConnectionManager;
         this.overseasConnectionManager = overseasConnectionManager;
@@ -88,6 +92,7 @@ public class LiveStockPriceWebsocketServiceImpl implements LiveStockPriceWebsock
         this.restTemplate = restTemplate;
         this.redisTemplate = redisTemplate;
         this.liveStockPriceWebSocketSaverService = liveStockPriceWebSocketSaverService;
+        this.applicationEventPublisher = applicationEventPublisher;
     }
 
     /* 구독 관리 메서드 */
@@ -271,6 +276,11 @@ public class LiveStockPriceWebsocketServiceImpl implements LiveStockPriceWebsock
             log.debug("{} 주식 중복 데이터 스킵: {}", marketName, dto.code());
             return; //똑같은 데이터면 무시
         }
+
+        //새로운 데이터를 받으면 -> 감시가 이벤트 발행
+        applicationEventPublisher.publishEvent(
+                new PriceAlertEvent(this,dto)
+        );
 
         //스케쥴러 + 웹소켓 연결 시작하자마자 받은 데이터 값(첫 데이터) 저장
         if(previous == null) {

--- a/infra/src/main/java/com/fintory/infra/util/SecurityUtil.java
+++ b/infra/src/main/java/com/fintory/infra/util/SecurityUtil.java
@@ -1,0 +1,35 @@
+package com.fintory.infra.util;
+
+
+import com.fintory.common.exception.DomainErrorCode;
+import com.fintory.common.exception.DomainException;
+import com.fintory.domain.child.model.Child;
+import com.fintory.infra.domain.child.repository.ChildRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+/*
+*  REVIEW
+* 현재 로그인한 사용자에 대한 정보를 가져오기 위한 유틸리티.
+* 의존성 문제로 인해 infra 모듈에서 생성
+* 혹시 다른 방식으로 얻어올 수 있다면 리뷰 달아주세요
+* */
+public class SecurityUtil {
+
+    private final ChildRepository childRepository;
+
+    public Child getCurrentChild(){
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        UserDetails userDetails = (UserDetails) authentication.getPrincipal(); //의존성 문제로 인해 CustomUserDetails 대신 UserDetails 사용
+
+        String username = userDetails.getUsername();
+
+        return childRepository.findByEmail(username)
+                .orElseThrow(()-> new DomainException(DomainErrorCode.USER_NOT_FOUND));
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈


## 📝작업 내용

- 알림 기능 설정
- 감시가 알림 기능 구현
- 리포트 생성 시 알림 기능 

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
.ENV -> 
- FIREBASE_CONFIG= 디코에 올려준 firebaseConfig.json ->을 디코에 보내준 사이트에서 한 줄로 만들어서 넣어주세용

> 현재 로그인한 사용자를 알아내는 메소드를 추가했는데 -> 기존에 이미 있다면 알려주세요!
> 감시가 -> targetPrice의 1% 이내에 currentPrice가 들어온다면 1회성 알림 설정하는 방식 => 만약 변경을 원하신다면 목요일 이후에 수정하겟습니다
> 프론트 코드가 있어야 테스트 가능해서 아직 테스트 x
> 디코에 프로젝트 번호랑 fireBaseConfig.json 올릴게요! 

- 전체적인 로직 -> 
1. 프론트 → FCM에서 토큰 발급받음
2. 프론트 → 백엔드에게 토큰 전송
3. 백엔드 → DB에 토큰 저장
4. [이벤트 발생] 감시가 조건 만족
5. 백엔드 → Firebase Admin SDK → FCM 서버
6. FCM 서버 → 프론트(안드로이드 기기)로 알림 전송

